### PR TITLE
Deleted symlink at public/data

### DIFF
--- a/public/data
+++ b/public/data
@@ -1,1 +1,0 @@
-/home/sarupbanskota/glittery/data


### PR DESCRIPTION
The existing symlink that pointed to a directory on Sarup's system was interfering when trying to create a project.
