### PR TITLE
Fixed alert message in authenticate_user

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -24,7 +24,7 @@ module SessionsHelper
 
   def authenticate_user!
     if !current_user
-      flash[:error] = 'You need to login before accessing this page!'
+      flash[:alert] = 'You need to login before accessing this page!'
       redirect_to login_path
     end
   end 


### PR DESCRIPTION
The message was being assigned to `flash[:error]`, but `views/shared/_messages.html.haml` only displays `flash[:alert]` and `flash[:notice]`. 
