### PR TITLE
Fixed turbolinks issue

### DIFF
--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -11,7 +11,7 @@
       %li
         = link_to "Delete project", project_path(@project.id), method: :delete, confirm: "Are you sure?"
       %li
-        = link_to 'Draw', File.join(@project.id.to_s, 'createsvg'), :class => 'draw'
+        = link_to 'Draw', File.join(@project.id.to_s, 'createsvg'), :class => 'draw', "data-no-turbolink" => true
 
       %li
         = link_to 'Add files', File.join(@project.id.to_s, 'newfile'), :class => 'files'


### PR DESCRIPTION
This won't be a permanent thing if we can find a better way to get Turbolinks to work with the gem. I've just changed it such that turbolinks will be disabled on the canvas drawing page.
