### PR TITLE
Fixed double comments problem, cleaned up comments controller. Fixes #85

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -12,17 +12,14 @@ class CommentsController < ApplicationController
   # that helps distinguish the nature of what these comments are for.
 
   def create
-    @comment = Comment.new :body  => params[:comment][:body],
-                           :issue => false
-    @comment.polycomment_type = params[:polycomment_type]
-    @comment.polycomment_id = params[:polycomment_id]
+    @comment = Comment.new(params[:comment])
     @comment.user = current_user                      
     if @comment.save
-      @comments = Comment.where(polycomment_type: params[:polycomment_type],
-                              polycomment_id: params[:polycomment_id])
+      @comments = Comment.where(polycomment_type: params[:comment][:polycomment_type],
+                              polycomment_id: params[:comment][:polycomment_id])
       @comments = @comments.paginate(page: 1, per_page: 10)
       respond_to do |format|
-        format.html { redirect_to project_path(params[:polycomment_id]) }
+        format.html { redirect_to project_path(params[:comment][:polycomment_id]) }
         format.js {}
       end
       #flash[:notice] = 'Your comment was posted!'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -56,6 +56,7 @@ class ProjectsController < ApplicationController
     @images = Dir.glob(File.join @project.path, '*')
     @comments = Comment.where(polycomment_type: "project", polycomment_id: @project.id)
     @comments = pg @comments, 10
+    @comment = Comment.new
     @ajax = params[:page].nil? || params[:page] == 1
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,7 @@
 class Comment < ActiveRecord::Base
   
   belongs_to :user
-  attr_accessible :body, :issue
+  attr_accessible :body, :issue, :polycomment_id, :polycomment_type
   validates :body, :presence => :true
 
   default_scope order: 'comments.created_at DESC'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
   has_many :projects
   has_many :glimages, :through => :projects
+  has_many :comments
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
    

--- a/app/views/comments/_new.html.haml
+++ b/app/views/comments/_new.html.haml
@@ -1,5 +1,6 @@
-= form_for Comment.new, remote: ajax do |f|
-  = hidden_field_tag 'polycomment_type', type
-  = hidden_field_tag 'polycomment_id', id 
+= form_for(comment, remote: ajax) do |f|
+  = f.hidden_field(:polycomment_type, :value => type)
+  = f.hidden_field(:polycomment_id, :value => id)
+  = f.hidden_field(:issue, :value => false)
   = f.text_area :body, :placeholder => 'Add your comment...'
-  = f.submit 
+  = f.submit

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -55,7 +55,7 @@
 = render 'images'
 
 .comment_form
-  = render partial: "comments/new", locals: {type: 'project', id: @project.id.to_s, ajax: @ajax}
+  = render partial: "comments/new", locals: {type: 'project', id: @project.id.to_s, ajax: @ajax, comment: @comment}
 
  
 %ul.comments


### PR DESCRIPTION
Turns out the double comments was due to rails loading the javascript files twice. So this isn't a fix, just a general cleanup.
