### PR TITLE
Precompile assets (fixes #57 )

### DIFF
--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -10,6 +10,6 @@
 #popd > /dev/null
 
 pushd ${OPENSHIFT_REPO_DIR} > /dev/null
-bundle exec rake assets:precompile
+#bundle exec rake assets:precompile
 bundle exec rake db:migrate RAILS_ENV="production"
 popd > /dev/null

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,7 +5,7 @@ Glitter::Application.configure do
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
-
+  config.assets.prefix = "/dev-assets"
   # Log error messages when you accidentally call methods on nil.
   config.whiny_nils = true
 


### PR DESCRIPTION
Fixes #57 

I've set the assets path in development mode is to `/dev-assets` so that precompiled assets don't get loaded twice in a development environment. Also, I've removed the openshift hook to precompile assets.  
