### PR TITLE
Fixed error that prevented people from commenting on commit history

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -19,7 +19,7 @@ class CommentsController < ApplicationController
                               polycomment_id: params[:comment][:polycomment_id])
       @comments = @comments.paginate(page: 1, per_page: 10)
       respond_to do |format|
-        format.html { redirect_to project_path(params[:comment][:polycomment_id]) }
+        format.html { redirect_to :back }
         format.js {}
       end
       #flash[:notice] = 'Your comment was posted!'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -89,6 +89,8 @@ class ProjectsController < ApplicationController
     @tree = repo.tree(params[:tree_id])
     @contents = @tree.contents
     @comments = Comment.where(polycomment_type: "commit", polycomment_id: params[:tree_id])
+    @comment = Comment.new
+    @id = params[:tree_id]
   end
 
   # Given a filename, view the state of the file in master.

--- a/app/views/comments/_comment_author.html.haml
+++ b/app/views/comments/_comment_author.html.haml
@@ -1,0 +1,12 @@
+- markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+.comment#currentuser
+  .comment-meta
+    = avatar(User.find(comment.user_id).email)
+    %p.author
+      = User.find(comment.user_id).username
+  .comment-time
+    %p.time
+      = distance_of_time_in_words_to_now comment.created_at
+      ago
+  .comment-body
+    = raw markdown.render comment.body

--- a/app/views/comments/_comment_current.html.haml
+++ b/app/views/comments/_comment_current.html.haml
@@ -9,5 +9,5 @@
       = distance_of_time_in_words_to_now comment.created_at
       ago
   .comment-body
-      = raw markdown.render comment.body
+    = raw markdown.render comment.body
   

--- a/app/views/projects/projectcommit.html.haml
+++ b/app/views/projects/projectcommit.html.haml
@@ -19,15 +19,5 @@
       - elsif logged_in? and comment.user_id == current_user.id
         = render 'comments/comment_current', :comment => comment
       - else 
-        = render 'comments/comment_normal'
-    = render 'comments/new'
-
-
-    .comment-body
-      = form_for Comment.new do |f|
-        = hidden_field_tag 'polycomment_type', 'commit'
-        = hidden_field_tag 'polycomment_id',  @tree.id.to_s
-        .comment_field
-          = f.text_field :body, :placeholder => 'Add your comment...'
-        .submit
-          = f.submit 
+        = render 'comments/comment_normal', comment: comment
+    = render 'comments/new', comment: @comment, ajax: false, type: "commit", id: @id


### PR DESCRIPTION
This pull request will cause a small glitch with pagination (it's really small, but it still bugs me). Nothing will break, just that pagination won't show unless you refresh the page. I'm going to fix that tomorrow when I experiment with using Kaminari
