### PR TITLE
Exclude private projects on inspire page

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -10,7 +10,7 @@ class ProjectsController < ApplicationController
   end
 
   def index
-    @projects = Project.where.not(id: current_user.id).where("updated_at > ?", 7.days.ago)
+    @projects = Project.where("private IS NOT TRUE AND user_id <> ?", current_user.id)
   end
 
   def destroy


### PR DESCRIPTION
I've removed the updated_at condition for now, as it doesn't _really_ tell you when the project files were **updated**, it's just when the Project record was updated.
