### PR TITLE
Remove stray links reported on #166

### DIFF
--- a/app/views/issues/index.html.haml
+++ b/app/views/issues/index.html.haml
@@ -70,16 +70,3 @@
               %li
                 Merged
 
-          %h1
-            Issues
-          %nav
-            %ul
-              %li.active
-                RFE
-              %li
-                Idea
-              %li
-                Critical
-              %li
-                Newbie Friendly
-

--- a/app/views/issues/new.html.haml
+++ b/app/views/issues/new.html.haml
@@ -28,20 +28,6 @@
             = f.text_area :description, placeholder: "(Markdown Enabled)..."
             %label Type
             = f.select(:type, options_for_select([['Bug',0],['Improvement',1]]))
-            = f.submit "Report Issue"  
-
-        %aside
-          %h1
-            New Issue
-          %nav
-            %ul
-              %li.active
-                RFE
-              %li
-                Idea
-              %li
-                Critical
-              %li
-                Newbie Friendly   
+            = f.submit "Report Issue"   
 
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -138,13 +138,13 @@
               %header DEVELOPER
               %ul
                 %li
-                  %a{href: "#"} Source
+                  %a{href: "http://github.com/glittergallery/GlitterGallery"} Source
                 %li
-                  %a{href: "#"} Wiki
+                  %a{href: "http://github.com/glittergallery/GlitterGallery/wiki"} Wiki
                 %li
-                  %a{href: "#"} Contribute
+                  %a{href: "http://github.com/glittergallery/GlitterGallery/issues"} Contribute
                 %li
-                  %a{href: "#"} Report Issue
+                  %a{href: "http://github.com/glittergallery/GlitterGallery/issues/new"} Report Issue
                   / close left aside
                   / Use article for central content
 
@@ -177,13 +177,11 @@
               %article
                 %ul
                   %li
-                    %a{href: "https://fedorahosted.org/design-team/ticket/330#comment:2"} Flock Tshirts
+                    %a{href: "https://github.com/fedoradesign/nextweb-assets"} Fedora.next Website Assets
                   %li
-                    %a{href: "http://sarupbanskota.fedorapeople.org/waartaa/"} Waartaa Logos
+                    %a{href: "https://github.com/fedoradesign/fedoramagazine-images"} Fedora Magazine Images
                   %li
-                    %a{href: "http://blog.linuxgrrl.com/2014/04/01/a-proposal-for-fedoras-website-considering-fedora-next/"} Fedora Websites
-                  %li
-                    %a{href: "http://blog.linuxgrrl.com/2014/06/05/son-of-more-fedora-next-logos/"} Fedora.next logos
+                    %a{href: "https://github.com/fedoradesign/mockups-getfedora"} New getFedora Mockups
 
             %section
               %header
@@ -192,11 +190,11 @@
               %article
                 %ul
                   %li
-                    %a{href: "http://rohitpaulk.roon.io/multiple-authentication-methods-with-devise-and-omniauth"} More social GG auth
+                    %a{href: "http://www.glittergallery.net/status"} GlitterGallery's current status
                   %li
-                    %a{href: "sarupbanskota.github.io/fedora/2014/05/22/glittergallery-more-gsoc-love.html"} GlitterGallery: 2X GSoC love this year!
+                    %a{href: "https://github.com/glittergallery/GlitterGallery/issues"} Open Issues
                   %li
-                    %a{href: "http://sarupbanskota.github.io/fedora/2014/06/07/init-redesigning-glittergallery-responsively.html"} Redesigning GlitterGallery
+                    %a{href: "http://www.glittergallery.net/blog"} GlitterBlog
                     
             %section
               %header
@@ -205,8 +203,8 @@
               %article
                 %ul
                   %li
-                    %a{href: "#"} Blog
+                    %a{href: "http://planet.fedoraproject.org/design/"} Fedora Design Planet
                   %li
-                    %a{href: "#"} FedoraGG
+                    %a{href: "https://fedoraproject.org/wiki/FAD_DesignTeam_2014"} Fedora Design Team FAD
                   %li
-                    %a{href: "#"} Talks
+                    %a{href: "https://lists.fedoraproject.org/pipermail/design-team/"} Fedora Design Archives 

--- a/app/views/projects/_project_toolbar.html.haml
+++ b/app/views/projects/_project_toolbar.html.haml
@@ -8,13 +8,6 @@
   %div{ data: "log" }
     %p
       = link_to 'Log', File.join(@project.urlbase, 'commits')
-  -#
-    %div{ data: "contributors" }
-      %p
-        Contributors
-  %div{ data: "milestones" }
-    %p
-      Milestones
   %div{ data: "issues" }
     %p
       = link_to "Issues", File.join(@project.urlbase, 'issues')

--- a/app/views/projects/settings.html.haml
+++ b/app/views/projects/settings.html.haml
@@ -41,10 +41,6 @@
             Project Settings
           %nav
             %ul
-              %li
-                %a{href: ""}Collaborators
-              %li
-                %a{href: ""}Resources
               %li.active
                 %a{href: ""}Delete
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -15,24 +15,6 @@
     %div
       %img{src: "/usercover.jpg"}
 
-  %section.social
-    %div
-      .active
-        %p
-          %a{href: "#"} Follow
-        %p
-          %a{href: "#"}
-            = @user.username
-      %div
-        %p
-          %a{href: "#"} 0
-        %p
-          %a{href: "#"} Followers
-      %div
-        %p
-          %a{href: "#"} 0
-        %p
-          %a{href: "#"} Following
 
   %section
     .feed


### PR DESCRIPTION
On the homepage, I've put some fedora stuff temporarily. Once we branch out specifically for fedora design team, we can update those links / generate them dynamically.
