### PR TITLE
Fix issue of public projects not appearing

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,7 +19,7 @@ class ProjectsController < ApplicationController
 
   #TODO Limit to popular/recent projects
   def index
-    @projects = Project.where.not(private: true, user_id: current_user.id)
+    @projects = Project.inspiring_projects_for current_user.id
   end
 
   def destroy

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -18,6 +18,11 @@ class Project < ActiveRecord::Base
   validates :user,
               presence: true
 
+  # Returns a list of public projects that belong to other users.
+  def self.inspiring_projects_for user_id
+    Project.where.not(private: true, user_id: user_id)
+  end
+
   def last_updated
     repo = barerepo
     repo.head.target.time

--- a/db/migrate/20150304042821_make_projects_public_by_default.rb
+++ b/db/migrate/20150304042821_make_projects_public_by_default.rb
@@ -1,0 +1,5 @@
+class MakeProjectsPublicByDefault < ActiveRecord::Migration
+  def change
+    change_column :projects, :private, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141011185537) do
+ActiveRecord::Schema.define(version: 20150304042821) do
 
   create_table "comments", force: true do |t|
     t.text     "body"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 20141011185537) do
     t.integer  "user_id"
     t.string   "path"
     t.integer  "parent"
-    t.boolean  "private"
+    t.boolean  "private",    default: false
     t.string   "uniqueurl"
     t.string   "urlbase"
   end

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -20,4 +20,15 @@ feature "Projects" do
         expect(find('.project header')).to have_content('testproject1') 
 	end
 
+	scenario "User creates a public project and other user can see it" do
+	  sign_up_with("t@test.com","test1","secret12345")
+	  click_button "Create first project!"
+	  fill_in "project_name", :with => "testproject1"
+	  click_button "Public"
+	  click_link "logout"
+	  sign_up_with("t2@test.com","test2","secret12345")
+	  visit "/inspire"
+	  expect(page).to have_no_content("Uh oh, looks like everyone's gotten lazy ;)")
+	  expect(page).to have_content('testproject1')
+	end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -22,6 +22,13 @@ describe Project do
   	expect(Rugged::Repository.new(File.join @project.path , 'satellite' , '.git')).to be_a(Rugged::Repository)
   end
   
+  it "gets list of inspiring projects" do
+	@project = FactoryGirl.create(:project)
+	FactoryGirl.create(:project, :name => 't2', private: true, user: @project.user)
+	expect(Project.inspiring_projects_for(@project.user.id).count).to eq(0)
+	expect(Project.inspiring_projects_for(@project.user.id+1).count).to eq(1)
+  end
+
   describe ".urlbase" do
   	it "is correct" do
   		@user = FactoryGirl.create(:user, :username => "sarup")

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -6,7 +6,7 @@ module Features
 			fill_in "user_password", :with => password
 			click_button "Login"
 		end
-		def sign_up_with(email,username,password,password_confirmation)
+		def sign_up_with(email,username,password,password_confirmation = password)
 			visit "/"
 			click_link "Sign Up?"
 			fill_in "user_email", :with => email


### PR DESCRIPTION
When viewing the '/inspiring' page, no one can see any public projects.
see 
SHA: a5c3785ed8d6a35868bc169f07e40e889087fd2e
 This is because we set value of private to true on creation when the user chooses to create a private project but do nothing to private when the user chooses public so its value remains nil. I've added a migration to make the 'private' column have a default value of false.
I've also added tests that would fail on previous commits but succeed with this one.