### PR TITLE
Fixed 'No-Image' Uploading

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -247,10 +247,10 @@ class ProjectsController < ApplicationController
 
   def file_upload
     @project = Project.find params[:id]
-    tmp = params[:file].tempfile
-    file = File.join @project.satellitedir, params[:file].original_filename
-    FileUtils.cp tmp.path, file
     if params[:file]
+      tmp = params[:file].tempfile
+      file = File.join @project.satellitedir, params[:file].original_filename
+      FileUtils.cp tmp.path, file
       image_commit @project, params[:file]
       flash[:notice] = "Your new image was added successfully! How sparkly!"
     else

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -254,7 +254,7 @@ class ProjectsController < ApplicationController
       image_commit @project, params[:file]
       flash[:notice] = "Your new image was added successfully! How sparkly!"
     else
-      flash[:alert]  = "Your new image didn't get saved! How sad :("
+      flash[:alert]  = "No image selected!"
     end
     redirect_to @project.urlbase
   end


### PR DESCRIPTION
If one clicks on the 'Upload File' button without actually selecting an image to upload, we get this:  http://gyazo.com/1f5511b5b1ef5cda7f51c158939e9f39

After this, we get:  http://gyazo.com/465bb476c1e58852eeda2a6bb02536f9
We could change the message to 'No image selected', but i'm not sure what other cases there can be when 'params[:file]' is nil.