### PR TITLE
fix comments on logs temporarily

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -15,14 +15,11 @@ class CommentsController < ApplicationController
       @comments = Comment.where(polycomment_type: params[:comment][:polycomment_type],
                               polycomment_id: params[:comment][:polycomment_id])
       @comments = @comments.paginate(page: 1, per_page: 10)
-      
+      project = Project.find_by(name: params[:comment][:project_name])
       if params[:comment][:polycomment_type] == 'project'
         action = 0
-        project = Project.find(params[:comment][:polycomment_id])
       elsif params[:comment][:polycomment_type] == 'issue'
         action = 5
-        issue = Issue.find(@comment.polycomment_id)
-        project = issue.project
       end
       victims = project.followers + [project.user]
       victims.delete(@comment.user)

--- a/app/views/comments/_new.html.haml
+++ b/app/views/comments/_new.html.haml
@@ -8,5 +8,6 @@
       = f.hidden_field(:polycomment_type, :value => type)
       = f.hidden_field(:polycomment_id, :value => id)
       = f.hidden_field(:issue, :value => false)
+      = f.hidden_field(:project_name, :value => @project.name)
       = f.text_field :body, :placeholder => 'In my opinion...'
       = f.submit

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -33,22 +33,7 @@ feature "Projects" do
     expect(page).to have_content('testproject1')
   end
 
-  scenario "User uploads file and thumbnail is created" do
-    sign_up_with("t@test.com","test1","secret12345")
-    click_button "Create first project!"
-    fill_in "project_name", :with => "testproject1"
-    click_button "Public"
-    click_button "Add first file!"
-    page.attach_file("file[]", 'spec/factories/files/happypanda.png')
-    click_button "Save changes"
-    expect(page).to have_selector("img[src$='happypanda.png']")
-    #TODO: move the following checks into another unit test after settling on a place for their functions.
-    project = Project.last
-    last_commit_id = project.barerepo.head.target_id
-    expect(File.exist?(project.thumbnail_for(last_commit_id,true))).to eq(true)
-  end
-
-  scenario "User uploads multiple files" do
+  scenario "User uploads multiple images" do
     sign_up_with("t@test.com","test1","secret12345")
     click_button "Create first project!"
     fill_in "project_name", :with => "testproject1"
@@ -60,17 +45,39 @@ feature "Projects" do
     expect(page).to have_selector("img[src$='naruto.png']")
   end
 
-  scenario "User sees logs for a project" do
-    sign_up_with("t@test.com","test1","secret12345")
-    click_button "Create first project!"
-    fill_in "project_name", :with => "testproject1"
-    click_button "Public"
-    click_button "Add first file!"
-    page.attach_file("file[]", 'spec/factories/files/happypanda.png')
-    click_button "Save changes"
-    click_link "Log"
-    expect(page).to have_link "Add new file happypanda.png"
-    last_commit_id = Project.last.barerepo.head.target_id
-    expect(page).to have_selector("img[src$='#{last_commit_id}']")
+  describe "After image upload" do
+
+    before :each do
+      sign_up_with("t@test.com","test1","secret12345")
+      click_button "Create first project!"
+      fill_in "project_name", :with => "testproject1"
+      click_button "Public"
+      click_button "Add first file!"
+      page.attach_file("file[]", 'spec/factories/files/happypanda.png')
+      click_button "Save changes"
+    end
+
+    scenario "User can see uploaded image" do
+      expect(page).to have_selector("img[src$='happypanda.png']")
+      #TODO: move the following checks into another unit test after settling on a place for their functions.
+      project = Project.last
+      last_commit_id = project.barerepo.head.target_id
+      expect(File.exist?(project.thumbnail_for(last_commit_id,true))).to eq(true)
+    end
+
+    scenario "User sees logs for a project" do
+      click_link "Log"
+      expect(page).to have_link "Add new file happypanda.png"
+      last_commit_id = Project.last.barerepo.head.target_id
+      expect(page).to have_selector("img[src$='#{last_commit_id}']")
+    end
+
+    scenario "User comments on a specific commit" do
+      click_link "Log"
+      click_link "Add new file happypanda.png"
+      fill_in "comment_body", :with => "test comment"
+      click_button "Create Comment"
+      expect(find('.comments')).to have_content("test comment")
+    end
   end
 end


### PR DESCRIPTION
When trying to make a comment on a log, an error would occur. This fixes the error and adds the test case that would fail before this commit. I still believe this is not the best way to handle this error... I'm currently rethinking the routes to produce better solution.