### PR TITLE
Fixed Error if No Project Exists (URL)

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -129,10 +129,6 @@ class ProjectsController < ApplicationController
 
   def show
     @images = []
-    if @project.blank?
-    redirect_to dashboard_path
-    flash[:alert] = 'The project does not exist.'
-    else
     barerepo = @project.barerepo
     unless barerepo.empty?
       headtree = barerepo.lookup barerepo.last_commit.tree_id
@@ -140,9 +136,9 @@ class ProjectsController < ApplicationController
       headtree.each do |blob|
         link = File.join @project.urlbase, 'master', blob[:name]
         @images.push({
-                       link: link,
-                       name: blob[:name],
-                       url: @project.imageurl(blob[:name])
+                        link: link,
+                        name: blob[:name],
+                        url: @project.imageurl(blob[:name])
                     })
       end
     end
@@ -153,7 +149,6 @@ class ProjectsController < ApplicationController
     @comments = pg @comments, 10
     @comment = Comment.new
     @ajax = params[:page].nil? || params[:page] == 1
-    end
   end
 
   def user_show
@@ -342,7 +337,12 @@ class ProjectsController < ApplicationController
 
   def return_context
     @user = User.find_by username: params[:username]
-    @project = Project.find_by user_id: @user.id, name: params[:project]
+    unless @user.blank?
+      @project = Project.find_by user_id: @user.id, name: params[:project]
+    end
+    if @project.blank?
+      render file: "#{Rails.root}/public/404.html", layout: false, status: 404
+    end  
   end
 
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -129,6 +129,10 @@ class ProjectsController < ApplicationController
 
   def show
     @images = []
+    if @project.blank?
+    redirect_to dashboard_path
+    flash[:alert] = 'The project does not exist.'
+    else
     barerepo = @project.barerepo
     unless barerepo.empty?
       headtree = barerepo.lookup barerepo.last_commit.tree_id
@@ -142,12 +146,14 @@ class ProjectsController < ApplicationController
                     })
       end
     end
+
     @comments = Comment.where( polycomment_type: "project",
                                polycomment_id: @project.id
                              )
     @comments = pg @comments, 10
     @comment = Comment.new
     @ajax = params[:page].nil? || params[:page] == 1
+    end
   end
 
   def user_show

--- a/app/views/comments/_new.html.haml
+++ b/app/views/comments/_new.html.haml
@@ -4,7 +4,7 @@
 - else
 
   %div
-    = form_for(comment, remote: ajax) do |f|
+    = form_for(comment, remote: true) do |f|
       = f.hidden_field(:polycomment_type, :value => type)
       = f.hidden_field(:polycomment_id, :value => id)
       = f.hidden_field(:issue, :value => false)

--- a/app/views/projects/user_show.html.haml
+++ b/app/views/projects/user_show.html.haml
@@ -15,7 +15,11 @@
       
   = render 'users/user_toolbar'
   = render 'shared/messages'
- 
+
+  - if @user != current_user && @projects.blank?
+    %section
+      .guide
+        %p No Projects available for #{@user.username}
 
   - unless @projects.empty?
     %section.album

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -87,5 +87,9 @@ describe ProjectsController, type: :controller do
       get :show, :username => @project.user.username, :project => @project.name
       expect(response).to render_template("show")
     end
+    it "renders 404 if not found" do
+      get :show, { id: 'not_existing_page_321' }
+      expect(response.status).to eq(404)
+    end
   end
 end


### PR DESCRIPTION
If someone access the URL as /username/any_project and that project doesn't exists, the application was reporting error.

Update/Fix: Added a check and redirect to dashboard if project doesn't exist.