### PR TITLE
Solves unprotected redirect warning on hakiri

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,5 +108,15 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(_)
     dashboard_path
   end
-
+ 
+  #raises error if match against regular expression patterns fails
+  def check_redirect(url)
+     begin
+       if path = URI.parse(url).path
+         redirect_to path
+       end
+     rescue URI::InvalidURIError
+       redirect_to '/'
+     end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,15 +108,11 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(_)
     dashboard_path
   end
- 
-  #raises error if match against regular expression patterns fails
+
+  # raises error if match against regular expression patterns fails
   def check_redirect(url)
-     begin
-       if path = URI.parse(url).path
-         redirect_to path
-       end
-     rescue URI::InvalidURIError
-       redirect_to '/'
-     end
+    redirect_to url if URI.parse(url).path
+    rescue URI::InvalidURIError
+      redirect_to '/'
   end
 end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -36,7 +36,7 @@ class IssuesController < ApplicationController
     @issue.project = @project
     @issue.status = 0
     if @issue.save
-      redirect_to(@project.urlbase)
+      check_redirect @project.urlbase
     else
       flash[:alert] = "Couldn't create an issue"
       redirect_to(dashboard_path)
@@ -49,10 +49,10 @@ class IssuesController < ApplicationController
       @issue.status = 1
       @issue.save
       flash[:notice] = 'Issue Closed'
-      redirect_to(@project.issues_url)
+      check_redirect @project.issues_url
     else
       flash[:alert] = "You don't have permission to close this issue"
-      redirect_to(@project.issues_url)
+      check_redirect @project.issues_url
     end
 
   end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -16,6 +16,6 @@ class NotificationsController < ApplicationController
     ).first
     notificationstatus.seen = true
     notificationstatus.save
-    redirect_to(notificationstatus.notification.url)
+    check_redirect notificationstatus.notification.url
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -40,7 +40,7 @@ class ProjectsController < ApplicationController
       redirect_to dashboard_path
     else
       flash[:error] = "You don't have permission for this command!"
-      redirect_to @project.urlbase
+      check_redirect @project.urlbase
     end
   end
 
@@ -59,7 +59,7 @@ class ProjectsController < ApplicationController
         notification.victims << current_user.followers
         notification.save!
       end
-      redirect_to project.urlbase
+      check_redirect project.urlbase
     else
       flash[:alert] = "Didn't save project!"
       redirect_to new_project_path
@@ -81,7 +81,7 @@ class ProjectsController < ApplicationController
       flash[:notice] = "You're the owner of this project, " \
                        'you automatically receive updates.'
     end
-    redirect_to @project.urlbase
+    check_redirect @project.urlbase
   end
 
   # DELETE /user_id/id/unfollow
@@ -93,7 +93,7 @@ class ProjectsController < ApplicationController
       flash[:notice] = 'You were not following ' \
                        "#{@user.username}/#{@project.name}"
     end
-    redirect_to @project.urlbase
+    check_redirect @project.urlbase
   end
 
   def tree_at(revision, path)
@@ -266,7 +266,7 @@ class ProjectsController < ApplicationController
     else
       flash[:alert] = 'No image selected!'
     end
-    redirect_to @project.urlbase
+    check_redirect @project.urlbase
   end
 
   def file_update
@@ -287,7 +287,7 @@ class ProjectsController < ApplicationController
       flash[:alert] = "Unable to update #{params[:image_name]}. " \
                       'The server ponies are sad.'
     end
-    redirect_to @project.urlbase
+    check_redirect @project.urlbase
   end
 
   def file_delete
@@ -296,33 +296,33 @@ class ProjectsController < ApplicationController
     satellite_delete @project.satelliterepo, params[:image_name]
     @project.pushtobare
     flash[:notice] = "#{params[:image_name]} has been deleted!"
-    redirect_to @project.urlbase
+    check_redirect @project.urlbase
   end
 
   def open
     @pull = PullRequest.find params[:pull_id]
     @pull.status = 'open'
     @pull.save
-    redirect_to @project.urlbase
+    check_redirect @project.urlbase
   end
 
   def close
     @pull = PullRequest.find params[:pull_id]
     @pull.status = 'closed'
     @pull.save
-    redirect_to @project.urlbase
+    check_redirect @project.urlbase
   end
 
   def fork
     child = @project.create_fork_project
     child.user = current_user
     if child.save
-      redirect_to child.urlbase
+      check_redirect child.urlbase
       # TODO: notifications
     else
       flash[:alert] = "Couldn't fork project. " \
                       "#{child.errors.full_messages.to_sentence}"
-      redirect_to @project.urlbase
+      check_redirect @project.urlbase
     end
   end
 
@@ -343,6 +343,6 @@ class ProjectsController < ApplicationController
     render_404 && return if @project.blank?
     return unless @project.deleted?
     flash[:alert] = 'The project you requested had been deleted.'
-    redirect_to user_path(@user)
+    check_redirect "/#{@user.username}"
   end
 end


### PR DESCRIPTION
Hakiri warnings seemed pretty valid. 
Adding :only_path => true wouldn't work because it needs hash table. Read [here](https://www.owasp.org/index.php/Ruby_on_Rails_Cheatsheet#Redirects_and_Forwards)
Following the same blog, I added a function which raises error if path to which we are redirecting doesn't matches the regular expression patterns

UPDATE:
Successfully used rebase :smirk: 