### PR TITLE
Remove hard coded origin and bare remotes from dummy repo in tests.

### DIFF
--- a/spec/factories/repos/dummy.git/config
+++ b/spec/factories/repos/dummy.git/config
@@ -2,8 +2,3 @@
 	repositoryformatversion = 0
 	filemode = true
 	bare = true
-[remote "origin"]
-	url = /home/themonster/Projects/mine/GlitterGallery/spec/factories/repos/dummy.git/
-[remote "bare"]
-	url = public/testdata/repos/sbanskota08@gmail.com/testproject/repo.git
-	fetch = +refs/heads/*:refs/remotes/bare/*

--- a/spec/support/models/repository_helpers.rb
+++ b/spec/support/models/repository_helpers.rb
@@ -5,7 +5,8 @@ module Models
     def initialize_dummy_repo project
       dummy_repo_path = "spec/factories/repos/dummy.git"
       repo = Rugged::Repository.new dummy_repo_path
-      bare = repo.remotes['bare'] || repo.remotes.create('bare',project.barerepopath)
+      coll = Rugged::RemoteCollection.new repo
+      bare = coll.create_anonymous project.barerepopath
       repo.push bare, ['refs/heads/master']
     end
   end


### PR DESCRIPTION
I had to add a dummy repo for testing in the last PR... There was a problem with it which is the hard coded bare remote. This fixes it and makes the remote created on the fly, without editing the config file.