### PR TITLE
fixes multiline code in actionmailer

### DIFF
--- a/app/mailers/notif_mailer.rb
+++ b/app/mailers/notif_mailer.rb
@@ -5,8 +5,8 @@ class NotifMailer < ActionMailer::Base
     @victim = victim
     @notification = notification
 
-    @subjecttext = notification.actor.username + notification.messageverb
-                  + notification.objectname
+    @subjecttext = notification.actor.username + notification.messageverb + \
+                   notification.objectname
     mail(to: @victim.email, subject: @subjecttext)
   end
 end


### PR DESCRIPTION
Problem with actionmailer doesn't end here. `notification.objectname` gives error when we try to send email for commits, as there is no object. Read [comment](https://github.com/glittergallery/GlitterGallery/pull/254#discussion_r26726918) on #254 for further details.