### PR TITLE
markup added to isssues and fix #191

### DIFF
--- a/app/assets/stylesheets/_markdown.scss
+++ b/app/assets/stylesheets/_markdown.scss
@@ -1,0 +1,75 @@
+@media screen and (min-width: 0em){
+  body{
+    .wrapper{
+      article{
+        section{
+          div{
+            div.option{
+              div.markdown{
+                h1, h2, h3, h4, h5, h6{
+                  background-color: #f9fafb;
+                  font-weight: bold;
+                  padding: 0.25em 0 0.25em 0;
+                  border-bottom: 1px solid #eee;
+                }
+                h1{
+                  font-size: 2.25em;
+                }
+                h2{
+                  font-size: 1.75em;
+                }
+                h3{
+                  font-size: 1.5em;
+                }
+                h4{
+                  font-size: 1.25em;
+                }
+                h5{
+                  font-size: 1em;
+                }
+                h6{
+                  font-size: 0.75em;
+                }
+
+                ul{
+                  padding-left: 1.25em;
+                }
+
+                ol{
+                  padding-left: 1.25em;
+                }
+
+                blockquote{
+                  padding: 0 15px;
+                  color: #777;
+                  border-left: 4px solid #ddd;
+                }
+
+                p{
+                  margin: 2% 0 2% 0;
+                }
+
+                pre{
+                  padding: 2%;
+                  overflow: auto;
+                }
+
+                code{
+                  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+                }
+
+                a{
+                  color: #27639E;
+                  text-decoration: none;
+                }
+                a:hover{
+                  text-decoration: underline;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -6,6 +6,7 @@
 @import 'jquery.sidr.light';
 
 // Elements
+@import '_markdown';
 @import '_button';
 @import '_comment';
 @import '_feed';

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,4 +45,14 @@ module ApplicationHelper
     log_status = user_signed_in? ? 'logged_in' : 'not_logged_in'
     "#{controller.controller_name} #{controller.action_name} #{log_status}"
   end
+
+  # render markdown text on redcarpet
+  def markdown(text)
+    render_options = { hard_wrap: true, filter_html: true }
+    markdown_options = { autolink: true, no_intra_emphasis: true }
+    markdown = Redcarpet::Markdown.new(
+      Redcarpet::Render::HTML.new(render_options), markdown_options
+    )
+    markdown.render(text).html_safe
+  end
 end

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,12 +1,10 @@
-- markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
-
 %div
   %header
     %h1
       = comment.user.username
   %article
     %p
-      = raw markdown.render comment.body
+      = markdown comment.body
   %footer
     %p
       = link_to 'Issue?', "#{@project.urlbase}/issues/new?desc=#{comment.body}"
@@ -18,5 +16,3 @@
                            data: { confirm: 'Are you sure?' }
     = distance_of_time_in_words_to_now comment.created_at
     ago
-
-

--- a/app/views/glitterposts/show.html.haml
+++ b/app/views/glitterposts/show.html.haml
@@ -1,4 +1,3 @@
-- markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
 - content_for :title do
   = @glitterpost.title.titleize
 
@@ -31,7 +30,7 @@
     ago
 
 %hr
-= raw markdown.render @glitterpost.content
+= markdown @glitterpost.content
 
 
 

--- a/app/views/issues/index.html.haml
+++ b/app/views/issues/index.html.haml
@@ -33,9 +33,6 @@
                       = link_to issue.title, issue_path(issue)
                       %span.badge.author
                         = issue.type_text
-                %article
-                  %p
-                    = markdown issue.description
                 %footer
                   %p
                     by

--- a/app/views/issues/index.html.haml
+++ b/app/views/issues/index.html.haml
@@ -35,7 +35,7 @@
                         = issue.type_text
                 %article
                   %p
-                    = issue.description
+                    = markdown issue.description
                 %footer
                   %p
                     by

--- a/app/views/issues/show.html.haml
+++ b/app/views/issues/show.html.haml
@@ -14,7 +14,7 @@
           %header
             %h1
               = @issue.title
-            .issue
+            .markdown
               = markdown @issue.description
         %aside
           %h1

--- a/app/views/issues/show.html.haml
+++ b/app/views/issues/show.html.haml
@@ -15,7 +15,7 @@
             %h1
               = @issue.title
             %h2.issue
-              = @issue.description
+              = markdown @issue.description
         %aside
           %h1
             Actions

--- a/app/views/issues/show.html.haml
+++ b/app/views/issues/show.html.haml
@@ -14,7 +14,7 @@
           %header
             %h1
               = @issue.title
-            %h2.issue
+            .issue
               = markdown @issue.description
         %aside
           %h1

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -55,8 +55,8 @@ feature 'Issues' do
 
       scenario 'User sees the issue' do
         expect(page).to have_content 'test issue'
-        expect(find('.issue')).to have_selector('h1', 'strong')
-        expect(find('.issue')).to have_content('head bold')
+        expect(find('.markdown')).to have_selector('h1', 'strong')
+        expect(find('.markdown')).to have_content('head bold')
       end
 
       scenario 'User reports another issue' do
@@ -96,8 +96,8 @@ feature 'Issues' do
           expect(page).to have_link 'test issue'
           click_link 'test issue'
           expect(page).to have_content 'test issue'
-          expect(find('.issue')).to have_selector('h1', 'strong')
-          expect(find('.issue')).to have_content('head bold')
+          expect(find('.markdown')).to have_selector('h1', 'strong')
+          expect(find('.markdown')).to have_content('head bold')
         end
 
         scenario 'User reopens an issue' do

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -38,7 +38,7 @@ feature 'Issues' do
     describe 'After reporting an issue' do
       before :each do
         fill_in 'issue[title]', with: 'test issue'
-        fill_in 'issue[description]', with: 'this is a test'
+        fill_in 'issue[description]', with: "# head \n\n **bold**"
         click_button 'Report Issue'
       end
 
@@ -55,7 +55,8 @@ feature 'Issues' do
 
       scenario 'User sees the issue' do
         expect(page).to have_content 'test issue'
-        expect(find('.issue')).to have_content 'this is a test'
+        expect(find('.issue')).to have_selector('h1', 'strong')
+        expect(find('.issue')).to have_content('head bold')
       end
 
       scenario 'User reports another issue' do
@@ -95,7 +96,8 @@ feature 'Issues' do
           expect(page).to have_link 'test issue'
           click_link 'test issue'
           expect(page).to have_content 'test issue'
-          expect(find('.issue')).to have_content 'this is a test'
+          expect(find('.issue')).to have_selector('h1', 'strong')
+          expect(find('.issue')).to have_content('head bold')
         end
 
         scenario 'User reopens an issue' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe ApplicationHelper, type: :helper do
+  describe '#markdown' do
+    it 'adds head tag to # text' do
+      markdown = helper.markdown '# I am head'
+      assert_equal "<h1>I am head</h1>\n", markdown
+    end
+
+    it 'adds strong and itallic tags' do
+      markdown = helper.markdown 'I am **bold** and *itallic*'
+      assert_equal '<p>I am <strong>bold</strong>' +
+                    " and <em>itallic</em></p>\n", markdown
+    end
+
+    it 'adds blockquote and code tags' do
+      markdown = helper.markdown ">quote\n\n `printf()`"
+      assert_equal "<blockquote>\n<p>quote</p>\n</blockquote>\n\n" +
+                   "<p><code>printf()</code></p>\n", markdown
+    end
+
+    it 'adds anchor tags' do
+      markdown = helper.markdown '[google](https://google.com)'
+      assert_equal "<p><a href=\"https://google.com\">google</a></p>\n",
+                   markdown
+    end
+
+    it 'adds ordered and unordered lists tags' do
+      markdown = helper.markdown "* Item 1\n* Item 2\n\n" +
+                                 "1. Item 1\n1. Item 2"
+      assert_equal "<ul>
+<li>Item 1</li>
+<li>Item 2</li>
+</ul>\n
+<ol>
+<li>Item 1</li>
+<li>Item 2</li>
+</ol>\n", markdown
+    end
+
+    it 'allows nesting heading tags' do
+      markdown = helper.markdown "# Head 1\n## Head 2\n### Head 3"
+      assert_equal "<h1>Head 1</h1>\n
+<h2>Head 2</h2>\n
+<h3>Head 3</h3>\n", markdown
+    end
+
+    it 'allows nesting of lists' do
+      markdown = helper.markdown "* list item 1
+* list item 2
+
+  * list item 2.1
+  * list item 2.2"
+      assert_equal "<ul>
+<li>list item 1</li>
+<li><p>list item 2</p>
+
+<ul>
+<li>list item 2.1</li>
+<li>list item 2.2</li>
+</ul></li>
+</ul>\n", markdown
+    end
+
+    it 'escapes html tags' do
+      markdown = helper.markdown "<a href=\"test\" " +
+                                 "onclick=\"alert('test')\">test;"
+      assert_equal "<p>test;</p>\n", markdown
+    end
+
+    it 'hard wraps new lines' do
+      markdown = helper.markdown "I am
+two lines"
+      assert_equal "<p>I am<br>
+two lines</p>\n", markdown
+    end
+  end
+end


### PR DESCRIPTION
Do we really need to support html tags? I am have set redcarpet to filter it, but if we really need it then I guess I can add that support. [Here](https://github.com/vmg/redcarpet/issues/434) it explains how html support can be added.

UPDATE:
Why bother about glitterpost? I want to reach no security warning on hakiri and changes I just made fixed few of XSS warnings, hence glitterposts!

**#In_Progress**