### PR TITLE
remove user email from path

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -150,7 +150,7 @@ class Project < ActiveRecord::Base
   def set_path
     user = User.find user_id
     self.data_path = File.join Glitter::Application.config.repo_dir,
-                               'repos', user.email.to_s, name
+                               'repos', user.username.to_s, name
     logger.debug "setting path - path: #{data_path}"
     save
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -65,7 +65,7 @@ describe Project do
   it 'gets thumbnails path' do
     @project = FactoryGirl.create(:project)
     commit_id = SecureRandom.hex(20)
-    real_path = "/testdata/repos/#{@project.user.email}/#{@project.name}/" \
+    real_path = "/testdata/repos/#{@project.user.username}/#{@project.name}/" \
                 "thumbnails/#{commit_id}"
     expect(@project.thumbnail_for(commit_id, false)).to eq(real_path)
     real_path = 'public' + real_path


### PR DESCRIPTION
If someone "opens image in new tab" (there are other ways too) then he would see something like :`http://localhost:3000/data/repos/aditya.prakash132@gmail.com/fancy_project/satellite/10407084_993180024044843_1803483709906686358_n.png`. I don't think we should keep user email public like that without permission of user.