### PR TITLE
fix #287: update image working

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -270,15 +270,11 @@ class ProjectsController < ApplicationController
   end
 
   def file_update
-    tmp = params[:file].tempfile
-    file = File.join @project.satellitedir, params[:image_name]
-    FileUtils.cp tmp.path, file
     if params[:file]
       imagefile = params[:file]
       message = params[:message]
       commit_id = satellite_commit @project.satelliterepo,
-                                   params[:image_name],
-                                   imagefile.read,
+                                   imagefile,
                                    message
       generate_thumbnail @project, params[:image_name], commit_id
       @project.pushtobare

--- a/app/views/projects/update.html.haml
+++ b/app/views/projects/update.html.haml
@@ -10,8 +10,8 @@
     %section
       %div
         = form_tag file_update_user_project_path(@project.user, @project), multipart: true do
-          = file_field_tag 'file'
-          = text_field_tag 'message', 'commit message'
+          = file_field_tag 'file[]'
+          = text_field_tag 'message', nil, placeholder: 'commit message'
           = hidden_field_tag 'image_name', params[:image_name]
           = submit_tag
 - else


### PR DESCRIPTION
closes #287 (hopefully)

Of course we need to add tests. Before that:
* When user click on `update` he is updating a single image, hence I am not allowing him to select multiple images. However, I am using an array of `ActionDispatch::Request` so that we can use same function `satellite_commit`. Am I right?
* When user update an `image1.jpg` with `image2.jpg`. We keep both copies of `image1` and `image2` in tree. Shouldn't we remove `image1.jpg` from tree?
* Can I take up #220? We already have #236 but there seems to be no activity on it. #220 needs to be fixed for me to write tests.

**#In_Progress** **#Need_Feedback**