### PR TITLE
Fix data_image_tag method to work correctly for SVGs + security fixes and improvements.

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -2,8 +2,7 @@ class IssuesController < ApplicationController
   before_action :get_context
 
   def index
-    @state = params[:state] || 'still_open'
-    @issues = @project.issues.send(@state)
+    @issues = @project.issues.status(params[:state] || 'open')
   end
 
   def new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -323,7 +323,7 @@ class ProjectsController < ApplicationController
     child = @project.create_fork_project
     child.user = current_user
     if child.save
-      redirect_to child.urlbase
+      redirect_to user_project_path child.user, child
       # TODO: notifications
     else
       flash[:alert] = "Couldn't fork project. " \

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,8 +8,8 @@ module ApplicationHelper
   def data_image_tag(image, width, height)
     extension = image[:name].split('.').last
     if extension == 'svg'
-      "<img src='data:image/svg+xml;utf8,
-        #{image[:data]}' width='#{width}' height='#{height}'/>"
+      "<img src='data:image/svg+xml;base64,
+        #{Base64.encode64(image[:data])}' width='#{width}' height='#{height}'/>"
         .html_safe
     elsif extension == 'jpg'
       "<img src='data:image/jpg;base64,

--- a/app/views/projects/_project_header.html.haml
+++ b/app/views/projects/_project_header.html.haml
@@ -16,7 +16,7 @@
       %span.badge.author PARENT
     - else
       %span.badge.author FORK
-      = render partial: 'forked_from', locals: { project: @project }
+      = render partial: 'projects/forked_from', locals: { project: @project }
 
   - if params[:oid] && params[:oid] != 'master'
     %p

--- a/spec/features/issues_spec.rb
+++ b/spec/features/issues_spec.rb
@@ -1,94 +1,118 @@
 require 'spec_helper'
 
 feature 'Issues' do
-  before :each do
-    sign_up_with('t@test.com', 'test1', 'secret12345')
-    click_button 'Create first project!'
-    fill_in 'project_name', with: 'testproject1'
-    click_button 'Public'
-    @project = Project.first
-    click_link 'Issues'
-    click_button 'Report Issue'
-  end
 
-  scenario 'User reports an issue only after filling needed fields' do
-    expect{click_button 'Report Issue'}.to_not change{@project.issues.count}
-    expect(page).to have_content "Title can't be blank"
-    expect(page).to have_content "Description can't be blank"
-    fill_in 'issue[title]', with: 'test_issue'
-    expect{click_button 'Report Issue'}.to_not change{@project.issues.count}
-    expect(page).to have_no_content "Title can't be blank"
-    expect(page).to have_content "Description can't be blank"
-    fill_in 'issue[description]', with: 'this is a test'
-    expect{click_button 'Report Issue'}.to change{@project.issues.count}.by(1)
-  end
-
-  describe 'After reporting an issue' do
+  shared_examples 'issue services' do |type, fork|
     before :each do
-      fill_in 'issue[title]', with: 'test issue'
-      fill_in 'issue[description]', with: 'this is a test'
+      sign_up_with('t@test.com', 'test1', 'secret12345')
+      click_button 'Create first project!'
+      fill_in 'project_name', with: 'testproject1'
+      if type == 'private'
+        click_button 'Private'
+      else
+        click_button 'Public'
+      end
+      if fork
+        click_link 'logout'
+        sign_up_with('t2@test.com', 'test2', 'secret12345')
+        visit 'test1/testproject1'
+        click_link 'Fork'
+      end
+      @project = Project.last
+      click_link 'Issues'
       click_button 'Report Issue'
     end
 
-    scenario 'User is redirected to the issue' do
-      expect(page.current_path).to eq(
-        user_project_issue_path(
-        @project.user,
-        @project,
-        nil,
-        @project.issues.first
-        )
-      )
-    end
-
-    scenario 'User sees the issue' do
-      expect(page).to have_content 'test issue'
-      expect(find('.issue')).to have_content 'this is a test'
-    end
-
-    scenario 'User reports another issue' do
-      click_link 'Issues'
-      click_button 'Report New Issue'
-      fill_in 'issue[title]', with: 'another test issue'
-      fill_in 'issue[description]', with: 'and this is another test'
+    scenario 'User reports an issue only after filling needed fields' do
+      expect{click_button 'Report Issue'}.to_not change{@project.issues.count}
+      expect(page).to have_content "Title can't be blank"
+      expect(page).to have_content "Description can't be blank"
+      fill_in 'issue[title]', with: 'test_issue'
+      expect{click_button 'Report Issue'}.to_not change{@project.issues.count}
+      expect(page).to have_no_content "Title can't be blank"
+      expect(page).to have_content "Description can't be blank"
+      fill_in 'issue[description]', with: 'this is a test'
       expect{click_button 'Report Issue'}.to change{@project.issues.count}.by(1)
     end
 
-    # TODO: Needs a revisit after defining abilities.
-    scenario 'User closes the issue and is redirected to issues page' do
-      expect{click_link 'Close'}.to change{@project.issues.closed.count}.by(1)
-      expect(@project.issues.still_open.count).to eq(0)
-      expect(page.current_path).to \
-      eq(user_project_issues_path(@project.user, @project, nil))
-      expect(page).to have_content 'No Issues to show!'
-    end
-
-    scenario 'User comments on the issue' do
-      fill_in 'comment[body]', with: 'a test comment'
-      expect{click_button 'Create Comment'}.to change{Comment.count}.by(1)
-      expect(page).to have_content 'a test comment'
-    end
-
-    describe 'After closing the issue' do
+    describe 'After reporting an issue' do
       before :each do
-        click_link 'Close'
-        click_link 'Closed'
+        fill_in 'issue[title]', with: 'test issue'
+        fill_in 'issue[description]', with: 'this is a test'
+        click_button 'Report Issue'
       end
 
-      scenario 'User sees closed issues' do
-        expect(page).to have_link 'test issue'
-        click_link 'test issue'
+      scenario 'User is redirected to the issue' do
+        expect(page.current_path).to eq(
+          user_project_issue_path(
+          @project.user,
+          @project,
+          @project.uniqueurl,
+          @project.issues.first
+          )
+        )
+      end
+
+      scenario 'User sees the issue' do
         expect(page).to have_content 'test issue'
         expect(find('.issue')).to have_content 'this is a test'
       end
 
-      scenario 'User reopens an issue' do
-        click_link 'test issue'
-        expect(find('//article//aside')).to have_link 'Reopen'
-        expect{click_link 'Reopen'}.to \
-        change{@project.issues.still_open.count}.by(1)
-        expect(@project.issues.closed.count).to eq(0)
+      scenario 'User reports another issue' do
+        click_link 'Issues'
+        click_button 'Report New Issue'
+        fill_in 'issue[title]', with: 'another test issue'
+        fill_in 'issue[description]', with: 'and this is another test'
+        expect{click_button 'Report Issue'}.to\
+          change{@project.issues.count}.by(1)
+      end
+
+      # TODO: Needs a revisit after defining abilities.
+      scenario 'User closes the issue and is redirected to issues page' do
+        expect{click_link 'Close'}.to change{@project.issues.closed.count}.by(1)
+        expect(@project.issues.open.count).to eq(0)
+        expect(page.current_path).to eq(user_project_issues_path(
+          @project.user,
+          @project,
+          @project.uniqueurl
+        ))
+        expect(page).to have_content 'No Issues to show!'
+      end
+
+      scenario 'User comments on the issue' do
+        fill_in 'comment[body]', with: 'a test comment'
+        expect{click_button 'Create Comment'}.to change{Comment.count}.by(1)
+        expect(page).to have_content 'a test comment'
+      end
+
+      describe 'After closing the issue' do
+        before :each do
+          click_link 'Close'
+          click_link 'Closed'
+        end
+
+        scenario 'User sees closed issues' do
+          expect(page).to have_link 'test issue'
+          click_link 'test issue'
+          expect(page).to have_content 'test issue'
+          expect(find('.issue')).to have_content 'this is a test'
+        end
+
+        scenario 'User reopens an issue' do
+          click_link 'test issue'
+          expect(find('//article//aside')).to have_link 'Reopen'
+          expect{click_link 'Reopen'}.to \
+          change{@project.issues.open.count}.by(1)
+          expect(@project.issues.closed.count).to eq(0)
+        end
       end
     end
   end
+
+  it_behaves_like 'issue services', 'public'
+
+  it_behaves_like 'issue services', 'private'
+
+  it_behaves_like 'issue services', 'public', 'fork'
+
 end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -46,9 +46,9 @@ describe Issue do
   it 'closes and reopens an issue' do
     issue = FactoryGirl.create(:issue)
     issue.close
-    expect(issue.status).to eq(1)
+    expect(issue.status).to eq('closed')
     issue.reopen
-    expect(issue.status).to eq(0)
+    expect(issue.status).to eq('open')
   end
 
   it 'prints type text' do
@@ -62,6 +62,17 @@ describe Issue do
     issue = FactoryGirl.create(:issue)
     real_path = "/#{issue.project.user.username}/#{issue.project.name}/issues/1"
     expect(issue.show_url).to eq(real_path)
+  end
+
+  it 'filters by state' do
+    issue1 = FactoryGirl.create(:issue)
+    project = issue1.project
+    issue2 = FactoryGirl.create(:issue, project: project)
+    expect(project.issues.status('open').count).to eq(2)
+    expect(project.issues.status('closed').count).to eq(0)
+    issue2.update_attributes(status: 1)
+    expect(project.issues.status('closed').count).to eq(1)
+    expect(project.issues.status('closed').count).to eq(1)
   end
 
   describe 'multiple projects' do


### PR DESCRIPTION
`data_image_tag` is the method we use now to show all images instead of `sketchily_show`. It turns out `data_image_tag` did not work for SVGs, this PR fixes it :)
see [here](https://github.com/glittergallery/GlitterGallery/pull/292#issuecomment-94199565)

Edit:
I added more to this PR. #292 reduced the number of security warnings from 22 to 8 but one of those 8 was actually introduced by the same PR :sweat_smile: Sorry for that but I fixed it here along with fixing another old security issue and a bug in the issues. I also made the tests of the issues run on private and forked projects(I did that because while browsing I detected a bug that only appeared on forked projects with issues.) Thinking of extending the project tests to run on forked projects too.
Notice that I replaced the status field of the issues with enum because it's more appropriate in our case. I was going to replace the types too but since we're replacing them with tags anyways, I didn't.