### PR TITLE
Repo file path improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ tmp/
 [._]s[a-w][a-z]
 *.un~
 
-# Ignore database config file
+# Ignore env specific config files
 /config/database.yml
+/config/initializers/0_glitterconfig.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.2.0
 before_script:
   - cp config/database.yml.example config/database.yml
+  - cp config/initializers/0_glitterconfig.rb.example config/initializers/0_glitterconfig.rb
   - psql -c 'create database travis_ci_test;' -U postgres
   - RAILS_ENV=test bundle exec rake --trace db:migrate
 script:

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -20,7 +20,8 @@ class ProjectsController < ApplicationController
                                               :network,
                                               :branches,
                                               :tree,
-                                              :diff
+                                              :diff,
+                                              :render_image
                                               ]
   authorize_resource except: [:followed_index]
 
@@ -369,6 +370,10 @@ class ProjectsController < ApplicationController
   end
 
   def settings
+  end
+
+  def render_image
+    send_file File.join(@project.data_path, params[:destination])
   end
 
   private

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -66,8 +66,8 @@ module ProjectsHelper
       }
     else
       images = project.find_inspire_image
-      mobile = project.image_for images, 'mobile_inspire', false
-      desktop = project.image_for images, 'desktop_inspire', false
+      mobile = project.image_for images, 'mobile_inspire'
+      desktop = project.image_for images, 'desktop_inspire'
       image_tag nil, class: 'img-placeholder', data: {
         mobile_url: mobile,
         desktop_url: desktop
@@ -78,8 +78,8 @@ module ProjectsHelper
   # render responsive images for project show page
   # uses jquery for setting src from data attribute
   def render_show_image(project, image_name)
-    mobile = project.image_for image_name, 'show_image_mob', false
-    desktop = project.image_for image_name, 'show_image_desk', false
+    mobile = project.image_for image_name, 'show_image_mob'
+    desktop = project.image_for image_name, 'show_image_desk'
     image_tag nil, class: 'img-placeholder', data: {
       mobile_url: mobile,
       desktop_url: desktop

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -30,7 +30,8 @@ class Ability
          :commit,
          :tree,
          :file_history,
-         :diff
+         :diff,
+         :render_image
         ], Project do |project|
       check_acess project, user
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -453,16 +453,19 @@ class Project < ActiveRecord::Base
 
     return if satelliterepo.empty?
     pushtobare
-    copy_inspire_images parent
+    copy_generated_images parent
   end
 
   # copy inspire image in fork from the parent project
-  def copy_inspire_images(parent)
+  def copy_generated_images(parent)
     img = parent.find_inspire_image
     mobile = parent.image_for img, 'mobile_inspire', true
     desktop = parent.image_for img, 'desktop_inspire', true
+    thumbnails = parent.image_for '', 'thumbnails', true
+
     FileUtils.cp(mobile, "#{data_path}/inspire/mobile")
     FileUtils.cp(desktop, "#{data_path}/inspire/desktop")
+    FileUtils.cp_r("#{thumbnails}/.", "#{data_path}/thumbnails")
   end
 
   # makes a symlink to hooks in gitlab-shell in each project

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -157,9 +157,9 @@ class Project < ActiveRecord::Base
   def resize_image(image_string, dest)
     image = Gg::ImageProcessing.new(image_string)
     i_name = dest.split('/').last
-    image.blob_generate(image_for(i_name, 'show', true))
-    image.blob_generate(image_for(i_name, 'show_image_desk', true), 'desktop')
-    image.blob_generate(image_for(i_name, 'show_image_mob', true), 'mobile')
+    image.blob_generate(image_for(i_name, 'show'))
+    image.blob_generate(image_for(i_name, 'show_image_desk'), 'desktop')
+    image.blob_generate(image_for(i_name, 'show_image_mob'), 'mobile')
   end
 
   # Takes a tree and the path to that tree.
@@ -226,7 +226,7 @@ class Project < ActiveRecord::Base
   # Generates a thumbnail for a commit in the appropriate place.
   def generate_thumbnail(image_path, commit_id)
     Gg::ImageProcessing.new("#{satellitedir}/#{image_path}")
-      .generate(image_for(commit_id, 'thumbnails', true), 'thumbnail')
+      .generate(image_for(commit_id, 'thumbnails'), 'thumbnail')
   end
 
   # returns last rugged::diff image name of the repo's head
@@ -269,8 +269,8 @@ class Project < ActiveRecord::Base
     FileUtils.rm_rf("#{image_for('', 'desktop_inspire')}/.", secure: true)
     image = Gg::ImageProcessing.new("#{satellitedir}/#{image_path}")
     i_name = image_path.split('/').last
-    image.generate(image_for(i_name, 'desktop_inspire', true), 'desktop')
-    image.generate(image_for(i_name, 'mobile_inspire', true), 'mobile')
+    image.generate(image_for(i_name, 'desktop_inspire'), 'desktop')
+    image.generate(image_for(i_name, 'mobile_inspire'), 'mobile')
   end
 
   # Returns a hash that can be passed to rugged while creating a commit
@@ -366,10 +366,9 @@ class Project < ActiveRecord::Base
 
   # Returns the path of the thumbnail for a specific commit
   # and images on inspire page
-  # if add_public is false "public/" is removed from the path.
   # dest argument determines where should the image be stored
   # if svg file_name is passed then it is first changed to png
-  def image_for(file_name, dest = '', add_public = true)
+  def image_for(file_name, dest = '')
     prefix = data_path.dup
     prefix.sub!('public', '') unless add_public
     file_name = file_name.split('/').last unless file_name.empty?
@@ -444,12 +443,12 @@ class Project < ActiveRecord::Base
       Rugged::Repository.init_at barerepopath, :bare
       Rugged::Repository.clone_at parent.satelliterepopath, satelliterepopath
     end
-    FileUtils.mkdir_p image_for('', 'mobile_inspire', true)
-    FileUtils.mkdir_p image_for('', 'desktop_inspire', true)
-    FileUtils.mkdir_p image_for('', 'thumbnails', true)
-    FileUtils.mkdir_p image_for('', 'show_image_desk', true)
-    FileUtils.mkdir_p image_for('', 'show_image_mob', true)
-    FileUtils.mkdir_p image_for('', 'show', true)
+    FileUtils.mkdir_p image_for('', 'mobile_inspire')
+    FileUtils.mkdir_p image_for('', 'desktop_inspire')
+    FileUtils.mkdir_p image_for('', 'thumbnails')
+    FileUtils.mkdir_p image_for('', 'show_image_desk')
+    FileUtils.mkdir_p image_for('', 'show_image_mob')
+    FileUtils.mkdir_p image_for('', 'show')
 
     return if satelliterepo.empty?
     pushtobare
@@ -459,9 +458,9 @@ class Project < ActiveRecord::Base
   # copy inspire image in fork from the parent project
   def copy_generated_images(parent)
     img = parent.find_inspire_image
-    mobile = parent.image_for img, 'mobile_inspire', true
-    desktop = parent.image_for img, 'desktop_inspire', true
-    thumbnails = parent.image_for '', 'thumbnails', true
+    mobile = parent.image_for img, 'mobile_inspire'
+    desktop = parent.image_for img, 'desktop_inspire'
+    thumbnails = parent.image_for '', 'thumbnails'
 
     FileUtils.cp(mobile, "#{data_path}/inspire/mobile")
     FileUtils.cp(desktop, "#{data_path}/inspire/desktop")
@@ -488,8 +487,8 @@ class Project < ActiveRecord::Base
 
   # Dumbs show-image folder content before walk
   def dump_show_img
-    FileUtils.rm_rf(Dir.glob("#{image_for('', 'show_image_desk', true)}/*"))
-    FileUtils.rm_rf(Dir.glob("#{image_for('', 'show_image_mob', true)}/*"))
-    FileUtils.rm_rf(Dir.glob("#{image_for('', 'show', true)}/*"))
+    FileUtils.rm_rf(Dir.glob("#{image_for('', 'show_image_desk')}/*"))
+    FileUtils.rm_rf(Dir.glob("#{image_for('', 'show_image_mob')}/*"))
+    FileUtils.rm_rf(Dir.glob("#{image_for('', 'show')}/*"))
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -425,8 +425,8 @@ class Project < ActiveRecord::Base
 
   def set_path
     user = User.find user_id
-    self.data_path = File.join Glitter::Application.config.repo_dir,
-                               'repos', user.username.to_s, name
+    self.data_path = File.join Glitter::Application.config.repo_path,
+                               user.username.to_s, name
     logger.debug "setting path - path: #{data_path}"
     save
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -370,7 +370,6 @@ class Project < ActiveRecord::Base
   # if svg file_name is passed then it is first changed to png
   def image_for(file_name, dest = '')
     prefix = data_path.dup
-    prefix.sub!('public', '') unless add_public
     file_name = file_name.split('/').last unless file_name.empty?
     file_name = file_name.gsub(/.svg/i, '.png')
     case dest

--- a/app/views/projects/_images.html.haml
+++ b/app/views/projects/_images.html.haml
@@ -15,7 +15,7 @@
       %div
         %p{ title: image[:name] }
           = link_to render_show_image(@project, image[:name]),
-            @project.image_for(image[:name], 'show', false),
+            @project.image_for(image[:name], 'show'),
             id: image[:name],
             class: 'swipebox'
           %span.name

--- a/app/views/projects/blob.html.haml
+++ b/app/views/projects/blob.html.haml
@@ -12,7 +12,7 @@
   %section.album
     .photo
       %p
-        = image_tag @project.image_for(@dest, 'show', false),
+        = image_tag @project.image_for(@dest, 'show'),
                     class: 'annotatable',
                     data: { id: @id }
     - if can? :file_update, @project

--- a/app/views/projects/commits.html.haml
+++ b/app/views/projects/commits.html.haml
@@ -20,7 +20,7 @@
               = commit.author[:name]
             %article
               %p
-                %img{ src: "#{@project.image_for(commit.oid, 'thumbnails', false)}" }
+                %img{ src: "#{@project.image_for(commit.oid, 'thumbnails')}" }
                 = link_to commit.message, commit_user_project_path(@project.user,
                   @project,
                   commit.oid)

--- a/config/initializers/0_glitterconfig.rb.example
+++ b/config/initializers/0_glitterconfig.rb.example
@@ -44,8 +44,10 @@ Glitter::Application.config.git_path = '/usr/bin/git'
 if Rails.env.development?
   Glitter::Application.config.repo_path = '/home/git/repos'
 elsif Rails.env.test?
-  Glitter::Application.config.repo_dir="public/testdata"
-  Glitter::Application.config.repo_path = "#{Rails.root}/public/testdata/repos"
+  # **WARNING**
+  # Content of repo_path's parent dir gets deleted after test. Don't chose path
+  # where you may lose data. Here testdata dir will be deleted
+  Glitter::Application.config.repo_path = "#{Rails.root}/testdata/repos"
 elsif Rails.env.production?
   Glitter::Application.config.repo_dir="public/data"
   Glitter::Application.config.repo_path = "#{ENV["OPENSHIFT_DATA_DIR"]}repos"

--- a/config/initializers/0_glitterconfig.rb.example
+++ b/config/initializers/0_glitterconfig.rb.example
@@ -44,12 +44,8 @@ Glitter::Application.config.git_path = '/usr/bin/git'
 if Rails.env.development?
   Glitter::Application.config.repo_path = '/home/git/repos'
 elsif Rails.env.test?
-  # **WARNING**
-  # Content of repo_path's parent dir gets deleted after test. Don't chose path
-  # where you may lose data. Here testdata dir will be deleted
-  Glitter::Application.config.repo_path = "#{Rails.root}/testdata/repos"
+  Glitter::Application.config.repo_path = "#{Rails.root}/testdata"
 elsif Rails.env.production?
-  Glitter::Application.config.repo_dir="public/data"
   Glitter::Application.config.repo_path = "#{ENV["OPENSHIFT_DATA_DIR"]}repos"
   Glitter::Application.config.action_mailer.smtp_settings={
   address:              ENV["MAIL_ADDRESS"],

--- a/config/initializers/0_glitterconfig.rb.example
+++ b/config/initializers/0_glitterconfig.rb.example
@@ -17,7 +17,7 @@ if Rails.env.development?
     Glitter::Application.config.default_avatar='https://raw.githubusercontent.com/glittergallery/GlitterGallery/master/public/happypanda.png'
 else
     Glitter::Application.config.default_avatar='/happypanda.png'
-end    
+end
 ## size of gravatar to ask for - one dimension in pixels
 ## (gravatars are square :))
 Glitter::Application.config.gravatar_size='48'
@@ -42,8 +42,7 @@ Glitter::Application.config.shell_path = File.join(Rails.root,'..','gitlab-shell
 Glitter::Application.config.action_mailer.delivery_method = :smtp
 Glitter::Application.config.git_path = '/usr/bin/git'
 if Rails.env.development?
-  Glitter::Application.config.repo_dir="public/data"
-  Glitter::Application.config.repo_path = "#{Rails.root}/public/data/repos"
+  Glitter::Application.config.repo_path = '/home/git/repos'
 elsif Rails.env.test?
   Glitter::Application.config.repo_dir="public/testdata"
   Glitter::Application.config.repo_path = "#{Rails.root}/public/testdata/repos"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Glitter::Application.routes.draw do
   get '/:user_id/:id/pull/:pull_id/close' => 'projects#close'
   get '/:user_id/:id/pull/:pull_id/open' => 'projects#open'
   get '/:user_id/:id/pulls' => 'projects#pulls'
+  get "#{Glitter::Application.config.repo_path}/:user_id/:id/*destination" => 'projects#render_image', as: :render_image, destination: /.+/
 
 
   resources :users, only: [:show], path: '/' do

--- a/lib/gg/image_processing.rb
+++ b/lib/gg/image_processing.rb
@@ -6,6 +6,8 @@ module Gg
   class ImageProcessing
     attr_reader :read_path
 
+    SUPPORTED_FILE_TYPES = ['.png', '.jepg', '.jpg', '.svg', '']
+
     def initialize(read_path)
       @read_path = read_path
     end
@@ -14,6 +16,7 @@ module Gg
     # at write_path. Used to generate images for inspire page
     # and commit thumbnails
     def generate(write_path, size_type)
+      return unless SUPPORTED_FILE_TYPES.include? File.extname(write_path)
       image = Magick::Image.read(read_path).first
       write_image image, write_path, size_type
     end
@@ -21,6 +24,7 @@ module Gg
     # Reads blob read_path and writes the (resized) image at write_path
     # Used to generate images for project show page
     def blob_generate(write_path, size_type = nil)
+      return unless SUPPORTED_FILE_TYPES.include? File.extname(write_path)
       image = Magick::Image.from_blob(read_path).first
       write_image image, write_path, size_type
     end

--- a/lib/gg/key_fingerprint.rb
+++ b/lib/gg/key_fingerprint.rb
@@ -44,7 +44,7 @@ module Gg
       version_matches = version_output.match(/OpenSSH_(?<major>\d+)\.(?<minor>\d+)/)
       return false unless version_matches
 
-      if version_matches[:major].to_i > 6 && version_matches[:minor].to_i > 8
+      if (version_matches[:major]+'.'+version_matches[:minor]).to_i >= 6.8
         return true
       else
         return false

--- a/lib/gg/search.rb
+++ b/lib/gg/search.rb
@@ -14,7 +14,7 @@ module Gg
       files.each do |f|
         next if (/#{query}/i =~ f).nil?
         f_name = f.sub(project.satellitedir + '/', '')
-        push = {name: f_name, path: f.sub('public', '')}
+        push = {name: f_name, path: f}
         File.file?(f) ? images << push : dir << push
       end
       [images, dir]

--- a/spec/lib/image_processing_spec.rb
+++ b/spec/lib/image_processing_spec.rb
@@ -8,7 +8,7 @@ describe Gg::ImageProcessing do
     before do
       add_image project, 'logo.svg'
       @commit = project.branch_commit nil
-      @write_path = project.image_for('logo.svg', 'mobile_inspire', true)
+      @write_path = project.image_for('logo.svg', 'mobile_inspire')
       @path = File.join project.image_for('', 'mobile_inspire'), '/*'
     end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -43,6 +43,7 @@ describe 'User' do
       it{ should be_able_to(:commit, project) }
       it{ should be_able_to(:tree, project) }
       it{ should be_able_to(:diff, project) }
+      it{ should be_able_to(:render_image, project) }
       it{ should be_able_to(:file_history, project) }
       it{ should be_able_to(:index, Issue) }
       it{ should be_able_to(:show, issue) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -6,6 +6,7 @@ describe Project do
   let(:user) { create(:user) }
   let(:user1) { create(:user) }
   let(:project) { create(:project, user: user) }
+  let(:repo_path) { Glitter::Application.config.repo_path }
 
   it 'has a valid factory' do
     expect(create(:project)).to be_valid
@@ -91,11 +92,9 @@ describe Project do
 
   it 'gets thumbnails path' do
     commit_id = SecureRandom.hex(20)
-    real_path = "/testdata/repos/#{project.user.username}/#{project.name}/" \
+    real_path = "#{repo_path}/#{project.user.username}/#{project.name}/" \
                 "thumbnails/#{commit_id}"
-    expect(project.image_for(commit_id, 'thumbnails', false)).to eq(real_path)
-    real_path = 'public' + real_path
-    expect(project.image_for(commit_id, 'thumbnails', true)).to eq(real_path)
+    expect(project.image_for(commit_id, 'thumbnails')).to eq(real_path)
   end
 
   describe 'image processing' do
@@ -103,49 +102,49 @@ describe Project do
 
     describe '#image_for' do
       it 'gets desktop images path' do
-        real_path = "/testdata/repos/#{project.user.username}/#{project.name}/"\
+        real_path = "#{repo_path}/#{project.user.username}/#{project.name}/"\
                     'inspire/desktop/happypanda.png'
-        expect(project.image_for('happypanda.png', 'desktop_inspire', false))
+        expect(project.image_for('happypanda.png', 'desktop_inspire'))
           .to eq(real_path)
       end
 
       it 'gets mobie images path' do
-        real_path = "/testdata/repos/#{project.user.username}/#{project.name}/"\
+        real_path = "#{repo_path}/#{project.user.username}/#{project.name}/"\
                     'inspire/mobile/happypanda.png'
-        expect(project.image_for('happypanda.png', 'mobile_inspire', false))
+        expect(project.image_for('happypanda.png', 'mobile_inspire'))
           .to eq(real_path)
       end
 
       it 'gets mobile show image path' do
-        real_path = "/testdata/repos/#{project.user.username}/#{project.name}/"\
+        real_path = "#{repo_path}/#{project.user.username}/#{project.name}/"\
                     'show_images/mobile/happypanda.png'
-        expect(project.image_for('happypanda.png', 'show_image_mob', false))
+        expect(project.image_for('happypanda.png', 'show_image_mob'))
           .to eq(real_path)
       end
 
       it 'gets desktop show image path' do
-        real_path = "/testdata/repos/#{project.user.username}/#{project.name}/"\
+        real_path = "#{repo_path}/#{project.user.username}/#{project.name}/"\
                     'show_images/desktop/happypanda.png'
-        expect(project.image_for('happypanda.png', 'show_image_desk', false))
+        expect(project.image_for('happypanda.png', 'show_image_desk'))
           .to eq(real_path)
       end
 
       it 'gets show image path' do
-        real_path = "/testdata/repos/#{project.user.username}/#{project.name}/"\
+        real_path = "#{repo_path}/#{project.user.username}/#{project.name}/"\
                     'show_images/show/happypanda.png'
-        expect(project.image_for('happypanda.png', 'show', false))
+        expect(project.image_for('happypanda.png', 'show'))
           .to eq(real_path)
       end
     end
 
     describe 'inspire images' do
       it 'generates desktop images for inspire page' do
-        desk_path = project.image_for 'happypanda.png', 'desktop_inspire', true
+        desk_path = project.image_for 'happypanda.png', 'desktop_inspire'
         expect(File.exists?(desk_path)).to be true
       end
 
       it 'generates mobile images for inspire page' do
-        mob_path = project.image_for 'happypanda.png', 'mobile_inspire', true
+        mob_path = project.image_for 'happypanda.png', 'mobile_inspire'
         expect(File.exists?(mob_path)).to be true
       end
     end
@@ -154,17 +153,17 @@ describe Project do
       before { project.browse_tree }
 
       it 'gets generates desktop image' do
-        desk_path = project.image_for 'happypanda.png', 'show_image_desk', true
+        desk_path = project.image_for 'happypanda.png', 'show_image_desk'
         expect(File.exists?(desk_path)).to be true
       end
 
       it 'gets generates mobile image' do
-        mob_path = project.image_for 'happypanda.png', 'show_image_mob', true
+        mob_path = project.image_for 'happypanda.png', 'show_image_mob'
         expect(File.exists?(mob_path)).to be true
       end
 
       it 'gets generates show image' do
-        show_path = project.image_for 'happypanda.png', 'show', true
+        show_path = project.image_for 'happypanda.png', 'show'
         expect(File.exists?(show_path)).to be true
       end
     end
@@ -284,17 +283,17 @@ describe Project do
     end
 
     it 'copies mobile inspire images from parent' do
-      path = File.join @child.image_for('', 'mobile_inspire', true), '/*'
+      path = File.join @child.image_for('', 'mobile_inspire'), '/*'
       expect(Dir[path]).to_not be_empty
     end
 
     it 'copies desktop inspire images from parent' do
-      path = File.join @child.image_for('', 'desktop_inspire', true), '/*'
+      path = File.join @child.image_for('', 'desktop_inspire'), '/*'
       expect(Dir[path]).to_not be_empty
     end
 
     it 'copies commit thumbnails from parent' do
-      path = File.join @child.image_for('', 'thumbnails', true), '/*'
+      path = File.join @child.image_for('', 'thumbnails'), '/*'
       expect(Dir[path]).to_not be_empty
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -4,6 +4,7 @@ include FileHelper
 
 describe Project do
   let(:user) { create(:user) }
+  let(:user1) { create(:user) }
   let(:project) { create(:project, user: user) }
 
   it 'has a valid factory' do
@@ -273,4 +274,29 @@ describe Project do
       expect(data.second.oid). to eq(sha)
     end
   end
+
+  # testing private method, so delete it if fails
+  describe '#copy_generated_images' do
+    before do
+      add_image project, 'happypanda.png'
+      (@child = project.create_fork_project).user = user1
+      @child.save
+    end
+
+    it 'copies mobile inspire images from parent' do
+      path = File.join @child.image_for('', 'mobile_inspire', true), '/*'
+      expect(Dir[path]).to_not be_empty
+    end
+
+    it 'copies desktop inspire images from parent' do
+      path = File.join @child.image_for('', 'desktop_inspire', true), '/*'
+      expect(Dir[path]).to_not be_empty
+    end
+
+    it 'copies commit thumbnails from parent' do
+      path = File.join @child.image_for('', 'thumbnails', true), '/*'
+      expect(Dir[path]).to_not be_empty
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,9 +51,9 @@ RSpec.configure do |config|
 
   config.after(:each) do
     if Rails.env.test? || Rails.env.cucumber?
-      FileUtils.rm_rf(File.join(
-        Rails.root,
-        Glitter::Application.config.repo_dir
+      FileUtils.rm_rf(File.expand_path(
+        "..",
+        Glitter::Application.config.repo_path
       ))
     end
     DatabaseCleaner.clean

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,7 @@ RSpec.configure do |config|
   config.after(:each) do
     if Rails.env.test? || Rails.env.cucumber?
       FileUtils.rm_rf(File.expand_path(
-        "..",
+        '..',
         Glitter::Application.config.repo_path
       ))
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,10 +51,7 @@ RSpec.configure do |config|
 
   config.after(:each) do
     if Rails.env.test? || Rails.env.cucumber?
-      FileUtils.rm_rf(File.expand_path(
-        '..',
-        Glitter::Application.config.repo_path
-      ))
+      FileUtils.rm_rf(Glitter::Application.config.repo_path)
     end
     DatabaseCleaner.clean
   end


### PR DESCRIPTION
commit thumbnails are broken on fork (check [here](http://glittergallery-dev.fedorainfracloud.org/sachinkamath/fancy_project/commits)) cause the folder was not copied from parent.

Yet to implement:
Move repos from public dir to outside rails app. It leaves private repos exposed to outside world as everything in public dir can be rendered directly. ie routing doesn't involve rails app.