### PR TITLE
Comment and notification improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_script:
 script:
   - bundle exec rubocop --config .rubocop.yml
   - RAILS_ENV=test xvfb-run bundle exec rspec
-  - bundle exec haml-lint app/views/
+  - bundle exec haml-lint app/**/*.html.haml

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,7 @@ group :test do
   gem 'rubocop', require: false
   gem 'haml-lint', require: false
   gem 'shoulda-matchers'
+  gem 'coveralls', require: false
 end
 
 # To use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,13 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1)
+    coveralls (0.8.6)
+      json (~> 1.8)
+      rest-client (>= 1.6.8, < 2)
+      simplecov (~> 0.10.0)
+      term-ansicolor (= 1.3)
+      thor (~> 0.19.1)
+      tins (= 1.6.0)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
     delayed_job (4.0.6)
@@ -100,6 +107,9 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    docile (1.1.5)
+    domain_name (0.5.25)
+      unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
     erubis (2.7.0)
     escape (0.0.4)
@@ -153,6 +163,8 @@ GEM
     hashie (3.4.0)
     hike (1.2.3)
     hitimes (1.2.2)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     ice_nine (0.11.1)
     jquery-rails (3.1.2)
@@ -184,6 +196,7 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nenv (0.2.0)
+    netrc (0.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     notiffany (0.0.6)
@@ -279,6 +292,10 @@ GEM
     ref (1.0.5)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rmagick (2.13.4)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
@@ -327,6 +344,11 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     sketchily (4.0.1)
       nokogiri
       rails (>= 3.1)
@@ -341,6 +363,8 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sysexits (1.2.0)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     test-unit (3.0.9)
       power_assert
     therubyracer (0.12.1)
@@ -351,6 +375,7 @@ GEM
     tilt (1.4.1)
     timers (4.0.1)
       hitimes
+    tins (1.6.0)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -358,6 +383,9 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.9.0)
       kgio (~> 2.6)
       rack
@@ -387,6 +415,7 @@ DEPENDENCIES
   capybara
   capybara-webkit (~> 1.4.1)
   coffee-rails
+  coveralls
   database_cleaner (~> 1.4.1)
   delayed_job_active_record (~> 4.0.3)
   devise

--- a/app/assets/javascripts/annotation.js
+++ b/app/assets/javascripts/annotation.js
@@ -28,7 +28,7 @@ anno.addHandler('onAnnotationCreated', function(annotation) {
     type: "POST",
     url: "/annotations",
     dataType: "JSON",
-    data: "annotation="+encodeURIComponent(JSON.stringify(annotation))+"&blob_id=" + blob_id(),
+    data: "annotation="+encodeURIComponent(JSON.stringify(annotation))+"&blob_id=" + blob_id()+"&url="+window.location.pathname,
     success: function(data) {
       annotation.id=data.id; // the annotation ID should match the database row ID so we can delete it if needed
       json_data = JSON.parse(data.json)

--- a/app/assets/stylesheets/_annotorious.scss
+++ b/app/assets/stylesheets/_annotorious.scss
@@ -5,7 +5,7 @@
       display: none !important;
     }
     .annotatable{
-      width: 100%;
+      max-width: 100%;
     }
     .wrapper{
       article.project{

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -57,7 +57,7 @@ class AnnotationsController < ApplicationController
         format.json { render json: :nothing }
       else
         full_error = @annotation.errors.full_messages
-        format.json { render json: { error: full_error }, status: 400 }
+        format.json { render json: { error: full_error }, status: 422 }
       end
     end
   end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -16,15 +16,7 @@ class AnnotationsController < ApplicationController
 
   # POST  /annotations
   def create
-    find_project
-    annotation_json = params[:annotation]
-    annotation_hash = JSON.parse(annotation_json)
-    @annotation = Annotation.new(
-      json: annotation_json,
-      text: annotation_hash['text'],
-      blob_id: params[:blob_id],
-      user_id: current_user.id
-    )
+    build_annotation
     respond_to do |format|
       if @annotation.save
         make_presentable(@annotation)
@@ -88,5 +80,17 @@ class AnnotationsController < ApplicationController
     names = params[:url].split('/')[1, 2]
     user = User.find_by username: names.first
     @project = Project.find_by user_id: user.id, name: names.second
+  end
+
+  def build_annotation
+    find_project
+    annotation_json = params[:annotation]
+    annotation_hash = JSON.parse(annotation_json)
+    @annotation = Annotation.new(
+      json: annotation_json,
+      text: annotation_hash['text'],
+      blob_id: params[:blob_id],
+      user_id: current_user.id
+    )
   end
 end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -29,7 +29,7 @@ class AnnotationsController < ApplicationController
       if @annotation.save
         make_presentable(@annotation)
         victims = @project.followers + [@project.user] - [@annotation.user]
-        notify_users 'annotation', 1, @annotation.id, victims, notification_url
+        notify_users 'annotation', @annotation.id, victims, notification_url
         format.json { render json: @annotation.as_json }
       else
         full_error = @annotation.errors.full_messages
@@ -85,7 +85,7 @@ class AnnotationsController < ApplicationController
   end
 
   def find_project
-    names = params[:url].split('/')[1,2]
+    names = params[:url].split('/')[1, 2]
     user = User.find_by username: names.first
     @project = Project.find_by user_id: user.id, name: names.second
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,7 @@ class ApplicationController < ActionController::Base
   end
 
   # used to deliver notification on various events
-  def notify_users(action, object_type, object_id, victims, url)
+  def notify_users(action, object_type, object_id, victims, url = nil)
     actions = { 'project_comment' => 0,
                 'follow_project' => 1,
                 'fork' => 2,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,11 +66,10 @@ class ApplicationController < ActionController::Base
   # if url has master in it then replace it with repo head
   def notification_url
     params[:url] = "#{params[:url]}#comment_#{@comment.id}" if @comment
-    encoded_url = URI.encode(params[:url])
-    match_data = encoded_url.match /((blob|tree)\/master)/
-    return encoded_url unless match_data
+    match_data = params[:url].match /((blob|tree)\/master)/
+    return params[:url] unless match_data
     replace_str = "#{match_data[2]}/#{@project.barerepo.head.target.oid}"
-    encoded_url.gsub /((blob|tree)\/master)/, replace_str
+    params[:url].gsub /((blob|tree)\/master)/, replace_str
   end
 
   # used to set user and projects obejcts from the params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,21 +58,25 @@ class ApplicationController < ActionController::Base
   end
 
   # used to deliver notification on various events
-  def notify_users(action, object_type, object_id, victims)
+  def notify_users(action, object_type, object_id, victims, url)
     actions = { 'project_comment' => 0,
                 'follow_project' => 1,
                 'fork' => 2,
                 'follow_user' => 3,
                 'project_create' => 4,
                 'issue_comment' => 5,
-                'issue_create' => 6
+                'issue_create' => 6,
+                'blob_comment' => 7,
+                'commit_comment' => 8,
+                'tree_comment' => 9
               }
     Notification.create(
           actor: current_user,
           action: actions[action],
           object_type: object_type,
           object_id: object_id,
-          victims: victims
+          victims: victims,
+          url: url
         )
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,7 +38,7 @@ class ApplicationController < ActionController::Base
   end
 
   # used to deliver notification on various events
-  def notify_users(action, object_id, victims, url = nil)
+  def notify_users(action, model_id, victims, url = nil)
     return if victims.empty?
     actions = { 'project_comment' => 0,
                 'follow_project' => 1,
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
     Notification.create(
           actor: current_user,
           action: actions[action],
-          object_id: object_id,
+          model_id: model_id,
           victims: victims,
           url: url
         )

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,50 @@ class ApplicationController < ActionController::Base
     things.paginate(page: params[:page], per_page: num) unless things.nil?
   end
 
+  # used to deliver notification on various events
+  def notify_users(action, object_type, object_id, victims, url = nil)
+    return if victims.empty?
+    actions = { 'project_comment' => 0,
+                'follow_project' => 1,
+                'fork' => 2,
+                'follow_user' => 3,
+                'project_create' => 4,
+                'issue_comment' => 5,
+                'issue_create' => 6,
+                'blob_comment' => 7,
+                'commit_comment' => 8,
+                'tree_comment' => 9,
+                'annotation' => 10
+              }
+    Notification.create(
+          actor: current_user,
+          action: actions[action],
+          object_type: object_type,
+          object_id: object_id,
+          victims: victims,
+          url: url
+        )
+  end
+
+  # if url comes from a comment then append comment id to url
+  # change space to %20 with URI
+  # if url has master in it then replace it with repo head
+  def notification_url
+    params[:url] = "#{params[:url]}#comment_#{@comment.id}" if @comment
+    encoded_url = URI.encode(params[:url])
+    match_data = encoded_url.match /((blob|tree)\/master)/
+    return encoded_url unless match_data
+    replace_str = "#{match_data[2]}/#{@project.barerepo.head.target.oid}"
+    encoded_url.gsub /((blob|tree)\/master)/, replace_str
+  end
+
+  # used to set user and projects obejcts from the params
+  def get_context
+    @user = User.find_by username: params[:user_id]
+    @project = Project.find_by user_id: @user.id, name: params[:project_id]
+    render_404 && return if @project.blank?
+  end
+
   protected
 
   def configure_devise_permitted_parameters
@@ -56,35 +100,4 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(_)
     dashboard_path
   end
-
-  # used to deliver notification on various events
-  def notify_users(action, object_type, object_id, victims, url = nil)
-    actions = { 'project_comment' => 0,
-                'follow_project' => 1,
-                'fork' => 2,
-                'follow_user' => 3,
-                'project_create' => 4,
-                'issue_comment' => 5,
-                'issue_create' => 6,
-                'blob_comment' => 7,
-                'commit_comment' => 8,
-                'tree_comment' => 9
-              }
-    Notification.create(
-          actor: current_user,
-          action: actions[action],
-          object_type: object_type,
-          object_id: object_id,
-          victims: victims,
-          url: url
-        )
-  end
-
-  # used to set user and projects obejcts from the params
-  def get_context
-    @user = User.find_by username: params[:user_id]
-    @project = Project.find_by user_id: @user.id, name: params[:project_id]
-    render_404 && return if @project.blank?
-  end
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,7 +38,7 @@ class ApplicationController < ActionController::Base
   end
 
   # used to deliver notification on various events
-  def notify_users(action, object_type, object_id, victims, url = nil)
+  def notify_users(action, object_id, victims, url = nil)
     return if victims.empty?
     actions = { 'project_comment' => 0,
                 'follow_project' => 1,
@@ -55,7 +55,6 @@ class ApplicationController < ActionController::Base
     Notification.create(
           actor: current_user,
           action: actions[action],
-          object_type: object_type,
           object_id: object_id,
           victims: victims,
           url: url

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -67,15 +67,16 @@ class CommentsController < ApplicationController
     @comments = Comment.where(
       polycomment_type: params[:comment][:polycomment_type],
       polycomment_id: "#{params[:comment][:polycomment_id]}"
-      )
-    @comments = pg @comments, 10
+    )
   end
 
   # if url has master in it then replace it with repo head
+  # and append comment id to url
   def notification_url
-    match_data = params[:url].match /((blob|tree)\/master)/
-    return params[:url] unless match_data
+    comment_url = "#{params[:url]}#comment_#{@comment.id}"
+    match_data = comment_url.match /((blob|tree)\/master)/
+    return comment_url unless match_data
     replace_str = "#{match_data[2]}/#{@project.barerepo.head.target.oid}"
-    params[:url].gsub /((blob|tree)\/master)/, replace_str
+    comment_url.gsub /((blob|tree)\/master)/, replace_str
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,7 @@
 class CommentsController < ApplicationController
   before_filter :authenticate_user!
+  before_action :get_context
+
   load_and_authorize_resource
 
   def new
@@ -14,11 +16,8 @@ class CommentsController < ApplicationController
       @comment.user = current_user
       if @comment.save
         @comments = find_project_comments
-        @project = Project.find_by(name: params[:comment][:project_name])
-        # action = 'project_comment' for projects or 'issue_comment' for issues
-        action = find_action
         victims = @project.followers + [@project.user] - [@comment.user]
-        notify_users action, 1, @comment.id, victims
+        notify_users @comment.action, 1, @comment.id, victims, notification_url
         respond_to do |format|
           format.html { redirect_to :back }
           format.js {}
@@ -43,40 +42,40 @@ class CommentsController < ApplicationController
   end
 
   private
-    def comment_params
-      params.require(:comment).permit(
-        :polycomment_id,
-        :polycomment_type,
-        :issue,
-        :body
+  def comment_params
+    params.require(:comment).permit(
+      :polycomment_id,
+      :polycomment_type,
+      :issue,
+      :body
+    )
+  end
+
+  # to check if polycomment object exists or not
+  def polycomment_exists
+    if %w(blob commit tree).include?(params[:comment][:polycomment_type])
+      return true
+    else
+      polycomment = params[:comment][:polycomment_type]
+      value = "#{params[:comment][:polycomment_id]}"
+      polycomment.classify.constantize.where(id: value).any?
+    end
+  end
+
+  # return all the comments associated with polycomment object
+  def find_project_comments
+    @comments = Comment.where(
+      polycomment_type: params[:comment][:polycomment_type],
+      polycomment_id: "#{params[:comment][:polycomment_id]}"
       )
-    end
+    @comments = pg @comments, 10
+  end
 
-    # to check if polycomment object exists or not
-    def polycomment_exists
-      if %w(blob commit file tree).include?(params[:comment][:polycomment_type])
-        return true
-      else
-        polycomment = params[:comment][:polycomment_type]
-        value = "#{params[:comment][:polycomment_id]}"
-        polycomment.classify.constantize.where(id: value).any?
-      end
-    end
-
-    # return all the comments associated with polycomment object
-    def find_project_comments
-      @comments = Comment.where(
-        polycomment_type: params[:comment][:polycomment_type],
-        polycomment_id: "#{params[:comment][:polycomment_id]}"
-        )
-      @comments = @comments.paginate(page: 1, per_page: 10)
-    end
-
-    def find_action
-      if params[:comment][:polycomment_type] == 'project'
-        return 'project_comment'
-      elsif params[:comment][:polycomment_type] == 'issue'
-        return 'issue_comment'
-      end
-    end
+  # if url has master in it then replace it with repo head
+  def notification_url
+    match_data = params[:url].match /((blob|tree)\/master)/
+    return params[:url] unless match_data
+    replace_str = "#{match_data[2]}/#{@project.barerepo.head.target.oid}"
+    params[:url].gsub /((blob|tree)\/master)/, replace_str
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -15,7 +15,6 @@ class CommentsController < ApplicationController
       @comment = Comment.new comment_params
       @comment.user = current_user
       if @comment.save
-        @comments = find_project_comments
         victims = @project.followers + [@project.user] - [@comment.user]
         notify_users @comment.action, 1, @comment.id, victims, notification_url
         respond_to do |format|
@@ -60,23 +59,5 @@ class CommentsController < ApplicationController
       value = "#{params[:comment][:polycomment_id]}"
       polycomment.classify.constantize.where(id: value).any?
     end
-  end
-
-  # return all the comments associated with polycomment object
-  def find_project_comments
-    @comments = Comment.where(
-      polycomment_type: params[:comment][:polycomment_type],
-      polycomment_id: "#{params[:comment][:polycomment_id]}"
-    )
-  end
-
-  # if url has master in it then replace it with repo head
-  # and append comment id to url
-  def notification_url
-    comment_url = "#{params[:url]}#comment_#{@comment.id}"
-    match_data = comment_url.match /((blob|tree)\/master)/
-    return comment_url unless match_data
-    replace_str = "#{match_data[2]}/#{@project.barerepo.head.target.oid}"
-    comment_url.gsub /((blob|tree)\/master)/, replace_str
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -16,7 +16,7 @@ class CommentsController < ApplicationController
       @comment.user = current_user
       if @comment.save
         victims = @project.followers + [@project.user] - [@comment.user]
-        notify_users @comment.action, 1, @comment.id, victims, notification_url
+        notify_users @comment.action, @comment.id, victims, notification_url
         respond_to do |format|
           format.html { redirect_to :back }
           format.js {}

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -35,7 +35,7 @@ class IssuesController < ApplicationController
           end
         end
         victims = @project.followers + [@project.user] - [@issue.user]
-        notify_users 'issue_create', 0, @issue.id, victims
+        notify_users 'issue_create', @issue.id, victims
         format.html { redirect_to @issue.show_url }
       else
         format.html { render 'new'}

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -18,9 +18,7 @@ class IssuesController < ApplicationController
       polycomment_type: 'issue',
       polycomment_id: "#{@issue.id}"
     )
-    @comments = pg @comments, 10
     @comment = Comment.new
-    @ajax = params[:page].nil? || params[:page] == 1
   end
 
   def create

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -35,7 +35,7 @@ class IssuesController < ApplicationController
           end
         end
         victims = @project.followers + [@project.user] - [@issue.user]
-        notify_users 'issue_create', 0, @project.id, victims
+        notify_users 'issue_create', 0, @issue.id, victims
         format.html { redirect_to @issue.show_url }
       else
         format.html { render 'new'}

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -16,6 +16,6 @@ class NotificationsController < ApplicationController
     ).first
     notificationstatus.seen = true
     notificationstatus.save
-    redirect_to(notificationstatus.notification.url)
+    redirect_to(notificationstatus.notification.redirect_url)
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -113,7 +113,6 @@ class ProjectsController < ApplicationController
     )
     @comment = Comment.new
     @id = blob.oid
-    @ajax = params[:page].nil? || params[:page] == 1
   end
 
   # GET /user/project/raw/branch_or_commit_oid/destination

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -111,7 +111,6 @@ class ProjectsController < ApplicationController
       polycomment_type: 'blob',
       polycomment_id: "#{blob.oid}"
     )
-    @comments = pg @comments, 10
     @comment = Comment.new
     @id = blob.oid
     @ajax = params[:page].nil? || params[:page] == 1
@@ -139,11 +138,9 @@ class ProjectsController < ApplicationController
       polycomment_type: 'project',
       polycomment_id: "#{@project.id}"
     )
-    @comments = pg @comments, 10
     @comment = Comment.new
     @comment_type = 'project'
     @id = @project.id.to_s
-    @ajax = params[:page].nil? || params[:page] == 1
   end
 
 
@@ -184,7 +181,6 @@ class ProjectsController < ApplicationController
       polycomment_type: 'commit',
       polycomment_id: "#{commit.oid}"
     )
-    @comments = pg @comments, 10
     @comment = Comment.new
     @id = commit.oid
   end
@@ -220,7 +216,6 @@ class ProjectsController < ApplicationController
       polycomment_id: "#{tree.oid}"
     )
     @comment_type = 'tree'
-    @comments = pg @comments, 10
     @comment = Comment.new
     @id = tree.oid
     render 'show'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -61,7 +61,7 @@ class ProjectsController < ApplicationController
       ProjectMember.add_owner project, current_user
       unless project.private
         # TODO: clean up action ids, numbers makes unreadable
-        notify_users 'project_create', 0, project.id, current_user.followers
+        notify_users 'project_create', project.id, current_user.followers
       end
       redirect_to user_project_path project.user, project
     else
@@ -80,7 +80,7 @@ class ProjectsController < ApplicationController
   def follow
     if @user != current_user
       current_user.follow_project @project
-      notify_users 'follow_project', 0, @project.id, [@project.user]
+      notify_users 'follow_project', @project.id, [@project.user]
       flash[:notice] = "You're now following #{@user.username}/#{@project.name}"
     else
       flash[:notice] = "You're the owner of this project, " \

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -17,7 +17,7 @@ class RelationshipsController < ApplicationController
     else
       @user.followers << current_user
       @user.save!
-      notify_users 'follow_user', 2, @user.id, [@user]
+      notify_users 'follow_user', @user.id, [@user]
       respond_to do |format|
         # TODO: it might be better to show flash messages on successful and
         # unsuccessful requests.

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,4 +3,20 @@ class Comment < ActiveRecord::Base
   validates :body, presence: true
 
   default_scope { order('comments.created_at ASC')}
+
+  # based on ploycomment_type it deterimnes the user action
+  def action
+    case polycomment_type
+    when 'project'
+      'project_comment'
+    when 'blob'
+      'blob_comment'
+    when 'commit'
+      'commit_comment'
+    when 'tree'
+      'tree_comment'
+    when 'issue'
+      'issue_comment'
+    end
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -17,6 +17,9 @@ class Notification < ActiveRecord::Base
   # 4: Created Project,
   # 5: Commented on Issue
   # 6: Created Issue
+  # 7: Commented on blob
+  # 8: Commented on commit
+  # 9: Commented on tree
   #
   # Object_type [0: Project, 1: Comment, 2: User]
   # Object_id - ID of the object
@@ -34,7 +37,7 @@ class Notification < ActiveRecord::Base
 
   def messageverb
     case action
-    when 0, 5
+    when 0, 5, 7, 8, 9
       ' commented on '
     when 1, 3
       ' followed '
@@ -52,6 +55,12 @@ class Notification < ActiveRecord::Base
     when 5
       return Issue.find(Comment.find(object_id).polycomment_id.to_i)
         .friendly_text
+    when 7
+      return "blob #{Comment.find(object_id).polycomment_id[0..6]}"
+    when 8
+      return "commit #{Comment.find(object_id).polycomment_id[0..6]}"
+    when 9
+      return "tree #{Comment.find(object_id).polycomment_id[0..6]}"
     when 3
       return User.find(object_id).username
     when 1, 2, 4
@@ -61,12 +70,14 @@ class Notification < ActiveRecord::Base
     end
   end
 
-  def url
+  def redirect_url
     case action
     when 0 # TODO: link directly to a comment
       return Project.find(Comment.find(object_id).polycomment_id.to_i).urlbase
     when 5
       return Issue.find(Comment.find(object_id).polycomment_id.to_i).show_url
+    when 7, 8, 9
+      return url
     when 1, 2, 4
       return Project.find(object_id).urlbase
     when 6

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -55,12 +55,9 @@ class Notification < ActiveRecord::Base
     when 5
       return Issue.find(Comment.find(object_id).polycomment_id.to_i)
         .friendly_text
-    when 7
-      return "blob #{Comment.find(object_id).polycomment_id[0..6]}"
-    when 8
-      return "commit #{Comment.find(object_id).polycomment_id[0..6]}"
-    when 9
-      return "tree #{Comment.find(object_id).polycomment_id[0..6]}"
+    when 7, 8, 9
+      comment = Comment.find(object_id)
+      return "#{comment.polycomment_type}: #{comment.polycomment_id[0..6]}"
     when 3
       return User.find(object_id).username
     when 1, 2, 4
@@ -72,11 +69,7 @@ class Notification < ActiveRecord::Base
 
   def redirect_url
     case action
-    when 0 # TODO: link directly to a comment
-      return Project.find(Comment.find(object_id).polycomment_id.to_i).urlbase
-    when 5
-      return Issue.find(Comment.find(object_id).polycomment_id.to_i).show_url
-    when 7, 8, 9
+    when 0, 7, 8, 9, 5
       return url
     when 1, 2, 4
       return Project.find(object_id).urlbase

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -80,7 +80,7 @@ class Notification < ActiveRecord::Base
       return Project.find(model_id).urlbase
     when 6
       return Issue.find(model_id).show_url
-    else
+    when 3
       return "/#{actor.username}"
     end
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -20,6 +20,7 @@ class Notification < ActiveRecord::Base
   # 7: Commented on blob
   # 8: Commented on commit
   # 9: Commented on tree
+  # 10: annotation
   #
   # Object_type [0: Project, 1: Comment, 2: User]
   # Object_id - ID of the object
@@ -45,6 +46,8 @@ class Notification < ActiveRecord::Base
       ' forked '
     when 4, 6
       ' created '
+    when 10
+      ' annotated '
     end
   end
 
@@ -58,6 +61,9 @@ class Notification < ActiveRecord::Base
     when 7, 8, 9
       comment = Comment.find(object_id)
       return "#{comment.polycomment_type}: #{comment.polycomment_id[0..6]}"
+    when 10
+      annotation = Annotation.find(object_id)
+      return "blob #{annotation.blob_id[0..6]}"
     when 3
       return User.find(object_id).username
     when 1, 2, 4
@@ -69,7 +75,7 @@ class Notification < ActiveRecord::Base
 
   def redirect_url
     case action
-    when 0, 7, 8, 9, 5
+    when 0, 7, 8, 9, 5, 10
       return url
     when 1, 2, 4
       return Project.find(object_id).urlbase

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -54,16 +54,13 @@ class Notification < ActiveRecord::Base
   def objectname
     case action
     when 0
-      return Project.find(Comment.find(object_id).polycomment_id.to_i).name
+      find_project_name
     when 5
-      return Issue.find(Comment.find(object_id).polycomment_id.to_i)
-        .friendly_text
+      find_issue_number
     when 7, 8, 9
-      comment = Comment.find(object_id)
-      return "#{comment.polycomment_type}: #{comment.polycomment_id[0..6]}"
+      find_comment_oid
     when 10
-      annotation = Annotation.find(object_id)
-      return "blob #{annotation.blob_id[0..6]}"
+      find_annotation_oid
     when 3
       return User.find(object_id).username
     when 1, 2, 4
@@ -84,5 +81,25 @@ class Notification < ActiveRecord::Base
     else
       return "/#{actor.username}"
     end
+  end
+
+  private
+
+  def find_project_name
+    Project.find(Comment.find(object_id).polycomment_id.to_i).name
+  end
+
+  def find_issue_number
+    Issue.find(Comment.find(object_id).polycomment_id.to_i).friendly_text
+  end
+
+  def find_comment_oid
+    comment = Comment.find(object_id)
+    "#{comment.polycomment_type}: #{comment.polycomment_id[0..6]}"
+  end
+
+  def find_annotation_oid
+    annotation = Annotation.find(object_id)
+    "blob #{annotation.blob_id[0..6]}"
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -22,7 +22,7 @@ class Notification < ActiveRecord::Base
   # 9: Commented on tree
   # 10: annotation
   #
-  # Object_type [0: Project, 1: Comment, 2: User]
+
   # Object_id - ID of the object
   # Victims - the people to be notified
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,6 +5,8 @@ class Notification < ActiveRecord::Base
                      class_name: 'User',
                      foreign_key: 'victim_id'
 
+  validates :action, :actor, :model_id, presence: true
+
   # TODO: clean up action ids, numbers makes unreadable
 
   # This class has the following information -
@@ -23,7 +25,7 @@ class Notification < ActiveRecord::Base
   # 10: annotation
   #
 
-  # Object_id - ID of the object
+  # model_id - ID of the object
   # Victims - the people to be notified
 
   after_create :send_emails
@@ -62,11 +64,11 @@ class Notification < ActiveRecord::Base
     when 10
       find_annotation_oid
     when 3
-      return User.find(object_id).username
+      return User.find(model_id).username
     when 1, 2, 4
-      return Project.find(object_id).name
+      return Project.find(model_id).name
     when 6
-      return Issue.find(object_id).friendly_text
+      return Issue.find(model_id).friendly_text
     end
   end
 
@@ -75,9 +77,9 @@ class Notification < ActiveRecord::Base
     when 0, 7, 8, 9, 5, 10
       return url
     when 1, 2, 4
-      return Project.find(object_id).urlbase
+      return Project.find(model_id).urlbase
     when 6
-      return Issue.find(object_id).show_url
+      return Issue.find(model_id).show_url
     else
       return "/#{actor.username}"
     end
@@ -86,20 +88,20 @@ class Notification < ActiveRecord::Base
   private
 
   def find_project_name
-    Project.find(Comment.find(object_id).polycomment_id.to_i).name
+    Project.find(Comment.find(model_id).polycomment_id.to_i).name
   end
 
   def find_issue_number
-    Issue.find(Comment.find(object_id).polycomment_id.to_i).friendly_text
+    Issue.find(Comment.find(model_id).polycomment_id.to_i).friendly_text
   end
 
   def find_comment_oid
-    comment = Comment.find(object_id)
+    comment = Comment.find(model_id)
     "#{comment.polycomment_type}: #{comment.polycomment_id[0..6]}"
   end
 
   def find_annotation_oid
-    annotation = Annotation.find(object_id)
+    annotation = Annotation.find(model_id)
     "blob #{annotation.blob_id[0..6]}"
   end
 end

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,4 +1,4 @@
-%div
+= div_for comment do
   %header
     %h1
       = comment.user.username
@@ -10,7 +10,7 @@
 
       - if can? :destroy, comment
         = link_to 'Delete?',
-                           comment_path(comment.id),
+                           user_project_comment_path(@project.user, @project, comment.id),
                            method: 'delete',
                            data: { confirm: 'Are you sure?' }
     = distance_of_time_in_words_to_now comment.created_at

--- a/app/views/comments/_show_comments.html.haml
+++ b/app/views/comments/_show_comments.html.haml
@@ -5,11 +5,11 @@
   %section.newcomment
     - if can? :create, @comment
       %div
-        = form_for(comment, remote: true) do |f|
+        = form_for([@project.user, @project, comment], remote: true) do |f|
           = f.hidden_field(:polycomment_type, value: type)
           = f.hidden_field(:polycomment_id, value: id)
           = f.hidden_field(:issue, value: false)
-          = f.hidden_field(:project_name, value: @project.name)
+          = hidden_field_tag(:url, request.original_fullpath)
           .expandingArea
             %pre
               %span

--- a/app/views/comments/_show_comments.html.haml
+++ b/app/views/comments/_show_comments.html.haml
@@ -16,5 +16,5 @@
           = f.submit class: 'comment_submit'
     - else
       %div
-        'You need to login to be able to comment!'
+        You need to login to be able to comment!
         = link_to 'Login now!', new_user_session_path

--- a/app/views/comments/_show_comments.html.haml
+++ b/app/views/comments/_show_comments.html.haml
@@ -1,7 +1,6 @@
 %section.comments
   %section.showcomments
     = render partial: 'comments/comment', collection: @comments
-    = will_paginate @comments
   %section.newcomment
     - if can? :create, @comment
       %div

--- a/app/views/comments/create.js.haml
+++ b/app/views/comments/create.js.haml
@@ -1,6 +1,5 @@
-:plain
-  $('.comments .showcomments').html("#{escape_javascript(
-    render partial: 'comments/comment',
-    collection: @comments
-  )}");
-  $('textarea').val('').trigger('input');
+var new_reply = $("#{escape_javascript(render partial: 'comments/comment', collection: [@comment])}").hide();
+$('.showcomments').append(new_reply);
+$("#comment_#{@comment.id}").fadeIn('slow');
+$('#new_comment')[0].reset();
+$('textarea').val('').trigger('input');

--- a/app/views/issues/show.html.haml
+++ b/app/views/issues/show.html.haml
@@ -32,5 +32,4 @@
 
   = render partial: 'comments/show_comments', locals: { type: 'issue',
     id: @issue.id.to_s,
-    ajax: @ajax,
     comment: @comment }

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -23,5 +23,5 @@
             = link_to(notif_string(notification) + 'you', notification_path(notification))
           - else
             = link_to(notif_string(notification) + notification.objectname,
-              notification_path(notification))
+              notification_path(notification), data: { no_turbolink: true })
 

--- a/app/views/projects/blob.html.haml
+++ b/app/views/projects/blob.html.haml
@@ -35,5 +35,4 @@
 
   = render partial: 'comments/show_comments', locals: { type: 'blob',
     id: @id,
-    ajax: @ajax,
     comment: @comment }

--- a/app/views/projects/commit.html.haml
+++ b/app/views/projects/commit.html.haml
@@ -23,5 +23,4 @@
 
   = render partial: 'comments/show_comments', locals: { type: action_name,
     id: @id.to_s,
-    ajax: @ajax,
     comment: @comment }

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -18,5 +18,4 @@
 
   = render partial: 'comments/show_comments', locals: { type: @comment_type,
       id: @id,
-      ajax: @ajax,
       comment: @comment }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,6 @@ Glitter::Application.routes.draw do
   resources :projects
   resources :keys, only: [:create, :index, :destroy]
   resources :identities, only: [:destroy,:index]
-  resources :comments, only: [:new, :create, :destroy]
   resources :glitterposts
   resources :notifications, only: [:index, :show]
   resources :project_members, only: [:destroy]
@@ -67,6 +66,7 @@ Glitter::Application.routes.draw do
       end
     end
     resources :projects, except: [:index], path: '/' do
+      resources :comments, only: [:new, :create, :destroy]
       resources :issues, except: [:show], path: "(:xid)/issues" do
         member do
           put 'close'

--- a/db/migrate/20151028050851_add_notification_url.rb
+++ b/db/migrate/20151028050851_add_notification_url.rb
@@ -1,0 +1,5 @@
+class AddNotificationUrl < ActiveRecord::Migration
+  def change
+    add_column :notifications, :url, :text
+  end
+end

--- a/db/migrate/20151107055550_remove_notification_object_type.rb
+++ b/db/migrate/20151107055550_remove_notification_object_type.rb
@@ -1,0 +1,5 @@
+class RemoveNotificationObjectType < ActiveRecord::Migration
+  def change
+    remove_column :notifications, :object_type, :integer
+  end
+end

--- a/db/migrate/20151114074219_rename_notification_object.rb
+++ b/db/migrate/20151114074219_rename_notification_object.rb
@@ -1,0 +1,5 @@
+class RenameNotificationObject < ActiveRecord::Migration
+  def change
+    rename_column :notifications, :object_id, :model_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151107055550) do
+ActiveRecord::Schema.define(version: 20151114074219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,7 +103,7 @@ ActiveRecord::Schema.define(version: 20151107055550) do
   create_table "notifications", force: true do |t|
     t.integer  "actor_id"
     t.integer  "action"
-    t.integer  "object_id"
+    t.integer  "model_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "url"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151004052308) do
+ActiveRecord::Schema.define(version: 20151028050851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 20151004052308) do
     t.integer  "object_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "url"
   end
 
   create_table "project_followers", force: true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151028050851) do
+ActiveRecord::Schema.define(version: 20151107055550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,7 +103,6 @@ ActiveRecord::Schema.define(version: 20151028050851) do
   create_table "notifications", force: true do |t|
     t.integer  "actor_id"
     t.integer  "action"
-    t.integer  "object_type"
     t.integer  "object_id"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -5,6 +5,7 @@ describe AnnotationsController, type: :controller do
   let(:other_user) { create(:user) }
   let(:project) { create(:project) }
   let(:annotation) { create(:annotation, user: user) }
+  let(:blob_oid) { 'fb82abfe99bb2be3b885b9cf72b7e05220dce165' }
   let(:annotation_param) do
     "{\"src\":\"http://localhost:3000/some/path\"," +
     "\"text\":\"flying monkeys\",\"shapes\":[{\"type\":\"rect\",\"geometry" +
@@ -22,19 +23,23 @@ describe AnnotationsController, type: :controller do
 
     it 'does not create new annotation' do
       post :create, format: :json,
-                    blob_id: 'fb82abfe99bb2be3b885b9cf72b7e05220dce165',
+                    blob_id: blob_oid,
                     annotation: annotation_param
       expect(user.annotations).to be_empty
     end
   end
 
   context 'user is signed in' do
-    before { sign_in(user) }
+    before do
+      sign_in(user)
+      @url = "/#{project.user.username}/#{project.name}/oid/some.png"
+    end
 
     it 'creates new annotation' do
       post :create, format: :json,
-                    blob_id: 'fb82abfe99bb2be3b885b9cf72b7e05220dce165',
-                    annotation: annotation_param
+                    blob_id: blob_oid,
+                    annotation: annotation_param,
+                    url: @url
       expect(user.annotations.last. text).to eq('flying monkeys')
     end
   end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,30 +1,32 @@
 require 'spec_helper'
 
 describe CommentsController, type: :controller do
+  let(:project) { create(:project) }
+  let(:user) { create(:user) }
+  let(:issue) { create (:issue) }
+
   context 'project exists' do
     describe 'POST #create' do
-      before do
-        @project = create(:project)
-        sign_in(@project.user)
-      end
+      before { sign_in(project.user) }
+
       it 'adds comment to project' do
         xhr :post, :create, comment: { polycomment_type: 'project',
-                                       polycomment_id: @project.id,
+                                       polycomment_id: project.id,
                                        issue: false,
-                                       project_name: @project.name,
                                        body: 'heads are cool'
-                                     }
+                                     },
+                            project_id: project.name,
+                            user_id: project.user.username
+
         expect(response.response_code).to eq(200)
-        expect(@project.user.comments.first.body).to eq('heads are cool')
+        expect(project.user.comments.first.body).to eq('heads are cool')
       end
     end
   end
 
   context "project doesn't exists" do
-    before do
-      @user = create(:user)
-      sign_in(@user)
-    end
+    before { sign_in(user) }
+
     describe 'POST #create' do
       it "doesn't create new comment" do
         xhr :post, :create, comment: { polycomment_type: 'project',
@@ -32,36 +34,37 @@ describe CommentsController, type: :controller do
                                        issue: false,
                                        project_name: "Dosesn't exists",
                                        body: 'Rock paper scissors'
-                                     }
+                                     },
+                            project_id: project.name,
+                            user_id: project.user.username
         expect(response.response_code).to eq(404)
-        expect(@user.comments).to be_empty
+        expect(user.comments).to be_empty
       end
     end
   end
 
   context 'issue exists' do
     describe 'POST #create' do
-      before do
-        @issue = create(:issue)
-        sign_in(@issue.user)
-      end
+      before { sign_in(issue.user) }
+
       it 'adds comment to project' do
         xhr :post, :create, comment: { polycomment_type: 'issue',
-                                       polycomment_id: @issue.id,
+                                       polycomment_id: issue.id,
                                        issue: false,
-                                       project_name: @issue.project.name,
+                                       project_name: issue.project.name,
                                        body: 'I am body of comment'
-                                     }
-        expect(@issue.user.comments.first.body).to eq('I am body of comment')
+                                     },
+                            project_id: issue.project.name,
+                            user_id: issue.project.user.username
+
+        expect(issue.user.comments.first.body).to eq('I am body of comment')
       end
     end
   end
 
   context "issue doesn't exists" do
-    before do
-      @user = create(:user)
-      sign_in(@user)
-    end
+    before { sign_in(user) }
+
     describe 'POST #create' do
       it "doesn't create new comment" do
         xhr :post, :create, comment: { polycomment_type: 'issue',
@@ -69,9 +72,12 @@ describe CommentsController, type: :controller do
                                        issue: false,
                                        project_name: "Dosesn't exists",
                                        body: 'I never existed'
-                                     }
+                                     },
+                            project_id: project.name,
+                            user_id: project.user.username
+
         expect(response.response_code).to eq(404)
-        expect(@user.comments).to be_empty
+        expect(user.comments).to be_empty
       end
     end
   end
@@ -79,23 +85,22 @@ describe CommentsController, type: :controller do
   context 'user is not logged in' do
     describe 'GET #new' do
       it 'redirects to sign in page' do
-        get :new
+        get :new, project_id: project.name, user_id: project.user.username
         expect(response).to redirect_to new_user_session_path
       end
-    end
-
-    before do
-      @project = create(:project)
     end
 
     describe 'POST #create' do
       it 'does not add comment' do
         xhr :post, :create, comment: { polycomment_type: 'project',
-                                       polycomment_id: @project.id,
+                                       polycomment_id: project.id,
                                        issue: false,
-                                       project_name: @project.name,
+                                       project_name: project.name,
                                        body: 'heads are cool'
-                                     }
+                                     },
+                            project_id: project.name,
+                            user_id: project.user.username
+
         expect(Comment.all).to be_empty
         expect(response.response_code).to eq(401) # unauthorized access
       end
@@ -104,16 +109,17 @@ describe CommentsController, type: :controller do
 
   context 'user is not owner of comment' do
     before do
-      @user = create(:user)
       @owner = create(:user, username: 'owner')
       @comment = create(:comment, user: @owner)
-      sign_in(@user)
+      sign_in(user)
     end
 
     describe 'DELETE #destroy' do
       it "doesn't deletes the comment" do
         @request.env['HTTP_REFERER'] = 'http://test.host'
-        delete :destroy, id: @comment.id
+        delete :destroy, id: @comment.id,
+                         project_id: project.name,
+                         user_id: project.user.username
         expect(response.response_code).to eq(403)
         expect(@owner.comments.first.body).to eq('fancy comment body')
       end
@@ -122,16 +128,17 @@ describe CommentsController, type: :controller do
 
   context 'user is owner of comment' do
     before do
-      @owner = create(:user, username: 'owner')
-      @comment = create(:comment, user: @owner)
-      sign_in(@owner)
+      @comment = create(:comment, user: user)
+      sign_in(user)
     end
 
     describe 'DELETE #destroy' do
       it 'deletes the comment' do
         @request.env['HTTP_REFERER'] = 'http://test.host'
-        delete :destroy, id: @comment.id
-        expect(@owner.comments).to be_empty
+        delete :destroy, id: @comment.id,
+                         project_id: project.name,
+                         user_id: project.user.username
+        expect(user.comments).to be_empty
       end
     end
   end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe CommentsController, type: :controller do
   let(:project) { create(:project) }
   let(:user) { create(:user) }
-  let(:issue) { create (:issue) }
+  let(:issue) { create(:issue) }
 
   context 'project exists' do
     describe 'POST #create' do

--- a/spec/controllers/keys_controller_spec.rb
+++ b/spec/controllers/keys_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe KeysController, type: :controller do
   let(:user) { create(:user) }
+  let(:key) { create(:key, user: user) }
   before { sign_in(user) }
 
   describe 'GET index' do
@@ -14,18 +15,27 @@ describe KeysController, type: :controller do
   describe 'POST create' do
     before do
       allow_any_instance_of(Key).to receive(:add_to_shell).and_return(true)
-    end
-    it 'adds key and redirects to key path' do
-      ssh_key =
+      @ssh_key =
         'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCx3ke+rnMT/ILY81K1un1CWf9ghcP' +
         'glIlV7pMV2H5AwyC/Dx5x+DyKmNmhBmvCYJ+1we8f0pPXLx2QpyAXw8s0s+sBL/gkiz' +
         'sqqwrUzK9Rlkj58kvNFl8gLQk3qqs8dR6bODP9LQqCGhMFErQtDQTvBq91jhWuIIunu' +
         'mK7T+0GWDMf7O9CNdr/aprYrUfuGLggOdz0oPja792V+ay1xWAHEOueKfGvOGFDbQlc' +
         'TT2uI9wYz9RGkLhDNOo4S74W59xMwMpf77XsoTYxcdrAT7WpTlzaj2usbbGBgcBKx5k' +
         'b0dPBOQ3rQadtZnLjN2dZAeapUO2MElyX0lxt1nrbIKC2 addie@host.localdomain'
-      post :create, key: { title: 'test', key: ssh_key }
+    end
+    it 'adds key and redirects to key path' do
+      post :create, key: { title: 'test', key: @ssh_key }
       expect(Key.last.title).to eq('test')
       expect(response).to redirect_to(keys_path)
+    end
+
+    context 'save fails' do
+      before { allow_any_instance_of(Key).to receive(:save).and_return(false) }
+      it 'does not add key' do
+        post :create, key: { title: 'test', key: @ssh_key }
+        expect(user.keys).to be_empty
+        expect(response).to render_template(:index)
+      end
     end
   end
 
@@ -35,11 +45,22 @@ describe KeysController, type: :controller do
       allow_any_instance_of(Key).to receive(:remove_from_shell).and_return(true)
       @request.env['HTTP_REFERER'] = 'http://test.host/keys'
     end
+
     it 'removes key and redirects to key path' do
-      key = create(:key, user: user)
       delete :destroy, id: key.id
       expect(Key.all.count).to be(0)
       expect(response).to redirect_to(keys_path)
+    end
+
+    context 'destroy fails' do
+      before do
+        allow_any_instance_of(Key).to receive(:destroy).and_return(false)
+      end
+      it 'does not remove key' do
+        delete :destroy, id: key.id
+        expect(Key.all.count).to be(1)
+        expect(flash[:alert]).to be_present
+      end
     end
   end
 end

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,5 +1,44 @@
 require 'spec_helper'
 
-describe NotificationsController do
+describe NotificationsController, type: :controller do
+  let(:user) { create(:user) }
+  let(:project) { create(:project) }
+  let(:notification) { create(:notification, victims: [user]) }
 
+  context 'user is signed in' do
+    before { sign_in(user) }
+
+    describe 'GET #index' do
+      it 'lists all the notification for the user' do
+        get :index
+        expect(response).to render_template('index')
+      end
+    end
+
+    describe 'GET #show' do
+      it 'redirects to notification url and marks it seen' do
+        get :show, id: notification.id
+        expect(notification.notification_statuses.first.seen).to be true
+        expect(response).to redirect_to notification.redirect_url
+      end
+    end
+  end
+
+  context 'user is guest' do
+    describe 'GET #index' do
+      it 'redirects to sign in page' do
+        get :index
+        expect(response).not_to render_template('index')
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    describe 'GET #show' do
+      it 'redirects to sign in page and does not mark it seen' do
+        get :show, id: notification.id
+        expect(notification.notification_statuses.first.seen).to be nil
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
 end

--- a/spec/controllers/project_members_controller_spec.rb
+++ b/spec/controllers/project_members_controller_spec.rb
@@ -17,6 +17,21 @@ describe ProjectMembersController, type: :controller do
         .to redirect_to(settings_user_project_path(project.user, project))
     end
 
+    describe 'duplicate member' do
+      before { make_member project, user }
+
+      it 'gets notified that duplicate memebers can not be added' do
+        post :create, user_id: project.user.username,
+                      project_id: project.name,
+                      member_id: user.id,
+                      role: 'collaborator'
+        expect(flash[:alert]).to be_present
+        path = user_project_project_members_path(project.user, project) +
+          "?search=#{user.username}"
+        expect(response).to redirect_to(path)
+      end
+    end
+
     it 'does not add project members as owner' do
       post :create, user_id: project.user.username,
                     project_id: project.name,

--- a/spec/factories/annotation.rb
+++ b/spec/factories/annotation.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :annotation do
-    text 'flying  monkeys'
+    text 'flying monkeys'
     blob_id '453bb23f7defbd153379a22284445dbfd8008295'
     json "{\"src\":\"http://localhost:3000/some/path\"," +
       "\"text\":\"flying monkeys\",\"shapes\":[{\"type\":\"rect\",\"geometry" +

--- a/spec/factories/notification_statuses.rb
+++ b/spec/factories/notification_statuses.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :notification_status do
     association :victim, factory: :user
     association :notification
+    seen nil
   end
 end

--- a/spec/factories/notification_statuses.rb
+++ b/spec/factories/notification_statuses.rb
@@ -1,6 +1,6 @@
-# Read about factories at https://github.com/thoughtbot/factory_girl
-
 FactoryGirl.define do
   factory :notification_status do
+    association :victim, factory: :user
+    association :notification
   end
 end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,6 +1,17 @@
-# Read about factories at https://github.com/thoughtbot/factory_girl
-
 FactoryGirl.define do
   factory :notification do
+    association :actor, factory: :user
+    action 0
+    model_id 1
+    url 'http://domain.name/user/project'
+
+    after(:create) do |notification|
+      new_user = create(:user)
+      notification.notification_statuses << create(
+        :notification_status,
+        notification: notification,
+        victim: new_user
+      )
+    end
   end
 end

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+include FileHelper
+
+feature 'Comments' do
+  let(:project) { create(:project) }
+  let(:user) { create(:user) }
+  let(:issue) { create(:issue) }
+
+  def fill_and_check_comment
+    fill_in 'comment[body]', with: 'Lorem ipsum dolor sit amet'
+    click_button 'Create Comment'
+    expect(page).to have_content 'Lorem ipsum dolor sit amet'
+  end
+
+  context 'user is signed in' do
+    before { login_as user }
+
+    scenario 'user comments on project', js: true do
+      visit project.urlbase
+      fill_and_check_comment
+    end
+
+    scenario 'user comments on issue', js: true do
+      visit issue.show_url
+      fill_and_check_comment
+    end
+
+    describe 'after image upload' do
+      before { add_image project, 'happypanda.png' }
+
+      scenario 'user comments on blob', js: true do
+        visit blob_user_project_path(
+                project.user,
+                project,
+                project.uniqueurl,
+                'master',
+                'happypanda.png'
+              )
+        fill_and_check_comment
+      end
+
+      scenario 'user comments on tree', js: true do
+        visit tree_user_project_path(
+                project.user,
+                project,
+                project.uniqueurl,
+                'master'
+              )
+        fill_and_check_comment
+      end
+
+      scenario 'user comments on commit', js: true do
+        visit commit_user_project_path(
+                project.user,
+                project,
+                project.uniqueurl,
+                project.barerepo.head.target_id
+              )
+        fill_and_check_comment
+      end
+    end
+  end
+
+  context 'user is not signed in' do
+    scenario 'user sees sign in request' do
+      visit project.urlbase
+      expect(page).to have_content 'You need to login to be able to comment!'
+    end
+  end
+end

--- a/spec/helpers/notifications_helper_spec.rb
+++ b/spec/helpers/notifications_helper_spec.rb
@@ -1,15 +1,12 @@
 require 'spec_helper'
 
-# Specs in this file have access to a helper object that includes
-# the NotificationsHelper. For example:
-#
-# describe NotificationsHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
-describe NotificationsHelper do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe NotificationsHelper, type: :helper do
+  let(:notification) { create(:notification) }
+
+  describe '#notif_string' do
+    it 'returns appeneded username and messageverb' do
+      expected_string = notification.actor.username + notification.messageverb
+      expect(notif_string notification).to eq(expected_string)
+    end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Comment do
+  let(:comment) { create(:comment) }
+
+  it 'has a valid factory' do
+    expect(comment).to be_valid
+  end
+
+  it 'is invalid without a body' do
+    expect(build(:comment, body: '')).to_not be_valid
+  end
+
+
+  describe '#action' do
+    shared_examples 'polycomment_type' do |type|
+      before { @comment = create(:comment, polycomment_type: type)}
+      it 'returns correct polycomment type' do
+        expect(@comment.action).to eq("#{type}_comment")
+      end
+    end
+
+    %w(project blob tree commit).each do |type|
+      it_behaves_like 'polycomment_type', type
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,5 +1,206 @@
 require 'spec_helper'
 
 describe Notification do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:notification) { create(:notification) }
+  let(:project) { create(:project) }
+  let(:issue) { create(:issue) }
+  let(:user) { create(:user) }
+
+  it 'has a valid factory' do
+    expect(notification).to be_valid
+  end
+
+  it 'is invalid without an actor' do
+    expect(build(:notification, actor: nil)).to_not be_valid
+  end
+
+  it 'is invalid without action' do
+    expect(build(:notification, action: nil)).to_not be_valid
+  end
+
+  it 'is invalid without model_id' do
+    expect(build(:notification, model_id: nil)).to_not be_valid
+  end
+
+  describe '#messageverb' do
+
+    shared_examples 'comment' do |action|
+      before { @notification = create(:notification, action: action)}
+      it 'returns correct messageverb' do
+        expect(@notification.messageverb).to eq(' commented on ')
+      end
+    end
+
+    [0, 5, 7, 8, 9].each { |action| it_behaves_like 'comment', action }
+
+    shared_examples 'follow' do |action|
+      before { @notification = create(:notification, action: action)}
+      it 'returns correct messageverb' do
+        expect(@notification.messageverb).to eq(' followed ')
+      end
+    end
+
+    [1, 3].each { |action| it_behaves_like 'follow', action }
+
+    context 'fork' do
+      before { @notification = create(:notification, action: 2)}
+      it 'returns correct messageverb' do
+        expect(@notification.messageverb).to eq(' forked ')
+      end
+    end
+
+    shared_examples 'create' do |action|
+      before { @notification = create(:notification, action: action)}
+      it 'returns correct messageverb' do
+        expect(@notification.messageverb).to eq(' created ')
+      end
+    end
+
+    [4, 6].each { |action| it_behaves_like 'create', action }
+
+    context 'annotation' do
+      before { @notification = create(:notification, action: 10)}
+      it 'returns correct messageverb' do
+        expect(@notification.messageverb).to eq(' annotated ')
+      end
+    end
+  end
+
+  describe '#objectname' do
+
+    context 'project comment' do
+      before do
+        comment = create(:comment, polycomment_id: project.id)
+        @notification = create(:notification, model_id: comment.id)
+      end
+
+      it 'returns project name' do
+        expect(@notification.objectname).to eq(project.name)
+      end
+    end
+
+    context 'issue comment' do
+      before do
+        comment = create(:comment, polycomment_id: issue.id)
+        @notification = create(:notification, action: 5, model_id: comment.id)
+      end
+
+      it 'return issue number' do
+        expect(@notification.objectname).to eq(issue.friendly_text)
+      end
+    end
+
+    context 'annotation' do
+      before do
+        @anno = create(:annotation)
+        @notification = create(:notification, action: 10, model_id: @anno.id)
+      end
+
+      it 'return blob with oid of annotation' do
+        expect(@notification.objectname).to eq("blob #{@anno.blob_id[0..6]}")
+      end
+    end
+
+    context 'user follow' do
+      before do
+        @notification = create(:notification, action: 3, model_id: user.id)
+      end
+
+      it 'return username' do
+        expect(@notification.objectname).to eq(user.username)
+      end
+    end
+
+    context 'issue create' do
+      before do
+        @notification = create(:notification, action: 6, model_id: issue.id)
+      end
+
+      it 'return issue number' do
+        expect(@notification.objectname).to eq(issue.friendly_text)
+      end
+    end
+
+    shared_examples 'git objects' do |action, type|
+      before do
+        @comment = create(:comment,
+                          polycomment_type: type,
+                          polycomment_id: 'a01331')
+        @notification = create(:notification,
+                               action: action,
+                               model_id: @comment.id)
+      end
+
+      it 'returns object name with oid' do
+        result = "#{@comment.polycomment_type}:" +
+                 " #{@comment.polycomment_id[0..6]}"
+        expect(@notification.objectname).to eq(result)
+      end
+    end
+
+    git_types = { 7 => 'blob', 8 => 'commit', 9 => 'tree' }
+    git_types.each { |key, value| it_behaves_like 'git objects', key, value }
+
+    shared_examples 'project actions' do |action|
+      before do
+        @notification = create(:notification,
+                               action: action,
+                               model_id: project.id)
+      end
+
+      it 'returns project name' do
+        expect(@notification.objectname).to eq(project.name)
+      end
+    end
+
+    [1, 2, 4].each { |action| it_behaves_like 'project actions', action }
+  end
+
+  describe '#redirect_url' do
+
+    shared_examples 'DB url' do |action|
+      before { @notification = create(:notification, action: action) }
+
+      it 'return urls stored in datbase' do
+        expect(@notification.redirect_url).to eq(@notification.url)
+      end
+    end
+
+    [0, 7, 8, 9, 5, 10].each { |action| it_behaves_like 'DB url', action }
+
+    shared_examples 'project actions' do |action|
+      before do
+        @notification = create(:notification,
+                               action: action,
+                               model_id: project.id)
+      end
+
+      it 'returns project name' do
+        expect(@notification.redirect_url).to eq(project.urlbase)
+      end
+    end
+
+    [1, 2, 4].each { |action| it_behaves_like 'project actions', action }
+
+    context 'issue create' do
+      before do
+        @notification = create(:notification, action: 6, model_id: issue.id)
+      end
+
+      it 'return issue number' do
+        expect(@notification.redirect_url).to eq(issue.show_url)
+      end
+    end
+
+    context 'user follow' do
+      before do
+        @notification = create(:notification, action: 3, model_id: user.id)
+      end
+
+      it 'return user name url' do
+        user_url = "/#{@notification.actor.username}"
+        expect(@notification.redirect_url).to eq(user_url)
+      end
+    end
+  end
 end

--- a/spec/models/notification_status_spec.rb
+++ b/spec/models/notification_status_spec.rb
@@ -1,5 +1,9 @@
 require 'spec_helper'
 
 describe NotificationStatus do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:notification_status) { create(:notification_status) }
+
+  it 'has a valid factory' do
+    expect(notification_status).to be_valid
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,12 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+
+# Load coveralls only in travis runs
+if ENV['TRAVIS']
+  require 'coveralls'
+  Coveralls.wear!('rails')
+end
+
 ENV['RAILS_ENV'] ||= 'test'
-require 'coveralls'
-Coveralls.wear!('rails')
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'capybara/rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
+require 'coveralls'
+Coveralls.wear!('rails')
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'capybara/rspec'


### PR DESCRIPTION
Changelog:
* Fix FOUC on blob page
* Deliver notification on annotation, comment on blob, tree and commit
* Save notification url in database instead of creating them
* Remove pagination from comments (May introduce infinite scroll later on)
* Redirect notification to comment id
* Fix notification url for issue create

Yet to do:
- [x] Tests 